### PR TITLE
Atomic releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,18 +203,20 @@ Templates use `{variable}` placeholders for Python string formatting and `{{vari
    - Copy Caddyfile if exists
    - Create `config.json` with deployment metadata
 4. **Create zipapp**: Bundle everything with `_installer/__main__.py` into `.pyz` file
-5. **Upload**: SCP zipapp to `/opt/fujin/{app_name}/.versions/{app_name}-{version}.pyz`
+5. **Upload**: SCP zipapp to `/tmp/fujin-{app_name}-{version}.pyz`
 6. **Verify**: SHA256 checksum verification
 7. **Execute**: Run `python3 installer.pyz install` on server
 8. **Prune**: Remove old versions (keeps `versions_to_keep` most recent)
 
 **Installer actions** (`_installer/__main__.py`):
 - Create app user if needed
-- Set up `/opt/fujin/{app_name}` directory
-- Install Python package (via uv) or copy binary
-- Create `.appenv` shell script for environment setup
-- Install systemd units and dropins
+- Set up `/opt/fujin/{app_name}` directory structure (releases/, shared/, .versions/)
+- Install Python package (via uv) or copy binary into `releases/{version}/`
+- Create `.appenv` shell script for environment setup (sources shared/.env)
+- Install systemd units and dropins (units reference `current/` symlink)
 - Enable and start services
+- Atomically swap `current` symlink to new release
+- Prune old releases (keeps last 3)
 - Configure Caddy if enabled
 
 ### Testing
@@ -328,8 +330,8 @@ UMask=0002  # Create files/sockets as group-writable
 
 **File Ownership:**
 - `/opt/fujin/{app_name}`: owned by `{deploy_user}:{app_user}`, mode `775`
-- `.install/` directory: owned by `{deploy_user}:{app_user}`, mode `775`
-- `.install/.env`: mode `640` (readable by group, not world)
+- `shared/` directory: owned by `{deploy_user}:{app_user}`, mode `775`
+- `shared/.env`: mode `640` (readable by group, not world)
 
 ### Why These Settings?
 

--- a/docs/commands/deploy.rst
+++ b/docs/commands/deploy.rst
@@ -39,7 +39,7 @@ Here's a high-level overview of what happens when you run the ``deploy`` command
    - Installer script (``_installer/__main__.py``)
    - Installation metadata (``config.json``)
 
-4. **Upload Bundle**: The zipapp is uploaded to a staging file (``.staging.pyz``) in ``{app_dir}/.install/.versions/``, then hardlinked to the versioned filename (``{app_name}-{version}.pyz``).
+4. **Upload Bundle**: The zipapp is uploaded to ``/tmp/fujin-{app_name}-{version}.pyz`` via SCP (with optional rsync for large bundles).
 
    - For bundles **≥1MB**: Fujin uses **rsync** if available on both local and remote machines. Rsync performs delta transfers, only uploading changed bytes—significantly faster for subsequent deployments where most content (dependencies) remains unchanged.
    - For bundles **<1MB** or when rsync is unavailable: Fujin uses **SCP** with SHA256 checksum verification.
@@ -49,17 +49,14 @@ Here's a high-level overview of what happens when you run the ``deploy`` command
 5. **Execute Installer**: The remote Python interpreter runs the zipapp (``python3 installer.pyz install``), which:
 
    - Creates the app user if needed
-   - Sets up the ``.install/`` directory structure
-   - Installs the application (creates virtualenv for Python packages, copies binary for binary mode)
-   - Creates ``.appenv`` shell environment setup
-   - Installs systemd units and dropin configurations
-   - Cleans up stale units and dropins
-   - Enables and restarts services
+   - Extracts the bundle into ``releases/{version}/``
+   - Creates a virtual environment and installs dependencies
+   - Runs ``post_install`` hooks (migrations, collectstatic, etc.)
+   - Atomically swaps the ``current`` symlink to activate the new release
+   - Prunes old releases (keeps ``versions_to_keep`` most recent)
    - Configures and reloads Caddy (when enabled)
 
-6. **Auto-Rollback on Failure**: If services fail to start after installation, Fujin automatically offers to roll back to the previous version. If you confirm (or use ``--no-input``), the previous bundle is re-executed and the failed bundle is removed.
-
-7. **Prune Old Bundles**: Old zipapp bundles are removed from ``.install/.versions/`` according to ``versions_to_keep`` configuration.
+6. **Cleanup**: The temporary bundle file is removed from ``/tmp/``.
 
 8. **Record Deployment**: Deployment metadata (version, timestamp, git commit) is appended to the audit log.
 
@@ -80,32 +77,40 @@ Directory Structure
         .. code-block:: shell
 
             /opt/fujin/{app_name}/
-            ├── .install/                         # Deployment infrastructure
-            │   ├── .env                          # Environment variables file (640)
-            │   ├── .appenv                       # Application-specific environment setup
-            │   ├── .version                      # Current deployed version
-            │   ├── .venv/                        # Virtual environment (Python from shared dir)
-            │   └── .versions/                    # Stored deployment bundles
-            │       ├── app-1.2.3.pyz
-            │       └── app-1.2.2.pyz
-            ├── db.sqlite3                        # App runtime data (owned by app user)
-            └── uploads/                          # App runtime data (owned by app user)
+            ├── current -> releases/1.2.3/        # Symlink to active release
+            ├── releases/
+            │   ├── 1.2.2/                        # Previous release (kept for rollback)
+            │   │   ├── .venv/
+            │   │   ├── .appenv
+            │   │   └── .version
+            │   └── 1.2.3/                        # Current release
+            │       ├── .venv/
+            │       ├── .appenv
+            │       └── .version
+            ├── shared/                           # Persistent data
+            │   └── .env                          # Environment variables (640)
+            ├── db.sqlite3                        # App runtime data
+            └── uploads/                          # App runtime data
 
     .. tab-item:: binary
 
         .. code-block:: shell
 
             /opt/fujin/{app_name}/
-            ├── .install/                         # Deployment infrastructure
-            │   ├── .env                          # Environment variables file (640)
-            │   ├── .appenv                       # Application-specific environment setup
-            │   ├── .version                      # Current deployed version
-            │   ├── app_binary                    # Installed binary (755)
-            │   └── .versions/                    # Stored deployment bundles
-            │       ├── app-1.2.3.pyz
-            │       └── app-1.2.2.pyz
-            ├── data/                             # App runtime data (owned by app user)
-            └── cache/                            # App runtime data (owned by app user)
+            ├── current -> releases/1.2.3/        # Symlink to active release
+            ├── releases/
+            │   ├── 1.2.2/
+            │   │   ├── app_binary
+            │   │   ├── .appenv
+            │   │   └── .version
+            │   └── 1.2.3/
+            │       ├── app_binary
+            │       ├── .appenv
+            │       └── .version
+            ├── shared/                           # Persistent data
+            │   └── .env                          # Environment variables (640)
+            ├── data/
+            └── cache/
 
 Shared Python Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -139,7 +144,7 @@ Fujin uses a multi-user security model with three components:
 
    - Member of ``fujin`` group
    - Can deploy and manage applications
-   - Owns ``.install/`` directory (deployment infrastructure)
+   - Owns app directory and release files
 
 3. **App user** (e.g., ``bookstore``): Runs services
 
@@ -148,10 +153,10 @@ Fujin uses a multi-user security model with three components:
    - Can write to database files and logs within app directory
    - Used automatically for ``fujin server exec --appenv`` and ``fujin app`` commands
 
-The ``.install/`` subdirectory isolates deployment infrastructure from application runtime data. This means:
+The ``releases/`` directory stores self-contained versioned releases, while ``shared/`` holds persistent data (``.env``, databases, uploads). This means:
 
-- Deployment operations (like ``chown``) only affect ``.install/``, not app data
-- App runtime files (databases, caches, uploads) remain owned by the app user
+- Deployment operations (like ``chown``) only affect the release being installed, not runtime data
+- App runtime files remain owned by the app user across deploys
 - No risk of permission conflicts between deployment and runtime operations
 
 .. note::
@@ -181,10 +186,14 @@ Example permissions:
     /opt/fujin/                      root:fujin       drwxrwxr-x (775)
       ├── .python/                   root:fujin       drwxrwxr-x (775)
       └── bookstore/                 tobi:bookstore   drwxrwxr-x (775)
-          ├── .install/              tobi:bookstore   drwxrwx--- (770)
-          │   ├── .env               tobi:bookstore   -rw-r----- (640)
-          │   └── .venv/             tobi:bookstore   drwxr-xr-x (755)
-          └── db.sqlite3             bookstore:...    -rw-r--r-- (664)
+          ├── current -> releases/1.2.3/
+          ├── releases/
+          │   └── 1.2.3/
+          │       ├── .env            tobi:bookstore   -rw-r----- (640) (via shared/)
+          │       └── .venv/          tobi:bookstore   drwxr-xr-x (755)
+          ├── shared/
+          │   └── .env                tobi:bookstore   -rw-r----- (640)
+          └── db.sqlite3              bookstore:...    -rw-r--r-- (664)
 
 Security Benefits
 ~~~~~~~~~~~~~~~~~

--- a/docs/commands/prune.rst
+++ b/docs/commands/prune.rst
@@ -1,7 +1,7 @@
 prune
 =====
 
-The ``fujin prune`` command removes old deployment bundles, keeping only a specified number of recent versions.
+The ``fujin prune`` command removes old release directories, keeping only a specified number of recent versions.
 
 .. image:: ../_static/images/help/prune-help.png
    :alt: fujin prune command help
@@ -10,9 +10,9 @@ The ``fujin prune`` command removes old deployment bundles, keeping only a speci
 Overview
 --------
 
-Over time, deployment bundles accumulate in ``~/.fujin/{app_name}/.versions/``. The prune command helps manage disk space by removing old versions while keeping recent ones for rollback capability.
+Over time, release directories accumulate in ``/opt/fujin/{app_name}/releases/``. Each release contains a full virtual environment (``.venv/``) and can be 50-200MB. The prune command helps manage disk space by removing old releases while keeping recent ones for rollback capability.
 
-Fujin automatically prunes old versions after each deployment based on the ``versions_to_keep`` setting in your ``fujin.toml``. Use ``fujin prune`` to manually clean up versions when you need to free up disk space or keep fewer versions than configured.
+Fujin automatically prunes old releases after each deployment based on the ``versions_to_keep`` setting in your ``fujin.toml``. Use ``fujin prune`` to manually clean up releases when you need to free up disk space or keep fewer versions than configured.
 
 Options
 -------
@@ -27,19 +27,17 @@ Here's what happens when you run ``fujin prune``:
 
 1. **Validate keep count**: Ensures ``--keep`` is at least 1.
 
-2. **Check versions directory**: Verifies the ``.versions/`` directory exists.
+2. **Check releases directory**: Verifies the ``releases/`` directory exists.
 
-3. **List bundles**: Lists all ``.pyz`` files in the versions directory, sorted by modification time (newest first).
+3. **List releases**: Lists all directories in the releases directory, sorted by modification time (newest first).
 
-4. **Filter valid bundles**: Identifies bundles matching the pattern ``{app_name}-{version}.pyz``.
+4. **Determine directories to delete**: If there are more releases than the keep count, selects the oldest releases for deletion.
 
-5. **Determine files to delete**: If there are more bundles than the keep count, selects the oldest bundles for deletion.
+5. **Prompt for confirmation**: Shows which versions will be deleted and asks for confirmation before proceeding.
 
-6. **Prompt for confirmation**: Shows which versions will be deleted and asks for confirmation before proceeding.
+6. **Delete old releases**: Removes the selected release directories.
 
-7. **Delete old bundles**: Removes the selected bundle files from the ``.versions/`` directory.
-
-The command is safe - it only removes old deployment bundles and doesn't affect your currently running application or services.
+The command is safe - it only removes old, inactive releases and doesn't affect your currently running application. The active release (pointed to by the ``current`` symlink) is never deleted.
 
 See Also
 --------

--- a/docs/commands/rollback.rst
+++ b/docs/commands/rollback.rst
@@ -10,38 +10,38 @@ The ``fujin rollback`` command rolls back your application to a previous version
 Overview
 --------
 
-When a deployment goes wrong, ``fujin rollback`` quickly reverts to a previous version. The command is fully interactive - it lists all available versions from the ``.versions/`` directory, prompts you to select which version to roll back to, and handles the complete rollback process.
+When a deployment goes wrong, ``fujin rollback`` quickly reverts to a previous version. The command is fully interactive - it lists all available versions from the ``releases/`` directory, prompts you to select which version to roll back to, and handles the complete rollback process.
 
-Fujin keeps deployment bundles in ``~/.fujin/{app_name}/.versions/`` as Python zipapps (``.pyz`` files). Each bundle is a self-contained executable containing everything needed to run that version: the application code, dependencies, environment variables, systemd units, and install/uninstall scripts.
+Fujin stores each deployed version as a self-contained directory in ``/opt/fujin/{app_name}/releases/``. Each release contains the full virtual environment, application code, and configuration. A ``current`` symlink points to the active release — rolling back simply swaps this symlink and restarts services.
 
 How it works
 ------------
 
 Here's what happens when you run ``fujin rollback``:
 
-1. **List available versions**: Scans the ``.versions/`` directory and lists available versions in reverse chronological order (most recent first).
+1. **List available versions**: Scans the ``releases/`` directory and lists available versions in reverse chronological order (most recent first).
 
 2. **Prompt for selection**: Asks you to select which version to roll back to, with the most recent version as the default.
 
 3. **Confirm rollback**: Shows the current version and target version, and asks for confirmation before proceeding.
 
-4. **Uninstall current version**: If a bundle exists for the current version, runs its uninstall script to cleanly remove the current deployment.
+4. **Swap symlink**: Atomically updates the ``current`` symlink to point to the selected release directory.
 
-5. **Install target version**: Extracts and runs the install script from the selected version's bundle.
+5. **Restart services**: Reloads systemd and restarts all application services, which now pick up the new symlink target.
 
-6. **Clean up newer versions**: Automatically deletes all versions newer than the selected target version to prevent accidentally re-deploying a broken version.
+6. **Clean up newer releases**: Automatically deletes all releases newer than the selected target version to prevent accidentally re-deploying a broken version.
 
 7. **Log operation**: Records the rollback operation to the audit log with from/to version information.
 
-Below is an example of the versions directory structure:
+Below is an example of the releases directory structure:
 
 .. code-block:: text
 
-   ~/.fujin/{app_name}/.versions/
-   ├── app-1.2.3.pyz
-   ├── app-1.2.2.pyz
-   ├── app-1.2.1.pyz
-   └── app-1.2.0.pyz
+   /opt/fujin/{app_name}/releases/
+   ├── 1.2.3/
+   ├── 1.2.2/
+   ├── 1.2.1/
+   └── 1.2.0/
 
 .. warning::
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -228,7 +228,8 @@ Hook commands support the same template variables as systemd unit files:
 - ``{app_dir}`` - Full path to application directory (``/opt/fujin/{app_name}``)
 - ``{app_user}`` - User running the app
 - ``{version}`` - Current version being deployed
-- ``{install_dir}`` - Path to ``.install`` directory
+- ``{shared_dir}`` - Persistent shared directory (``/opt/fujin/{app_name}/shared``)
+- ``{user}`` - The SSH deploy user
 
 Complete Example
 ~~~~~~~~~~~~~~~~

--- a/scripts/migrate-to-releases.sh
+++ b/scripts/migrate-to-releases.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Migration script: convert fujin-deployed apps from the old .install/ structure
+# to the new release-based atomic deployment structure.
+#
+# Run on the server for each deployed app:
+#   sudo bash migrate-to-releases.sh myapp
+#
+# What it does:
+#   1. Reads current version from .install/.version
+#   2. Creates releases/ and shared/ directories
+#   3. Moves .install/ contents into releases/{version}/
+#   4. Moves .env to shared/
+#   5. Creates current -> releases/{version} symlink
+#   6. Moves .versions/ to app_dir root
+#   7. Updates systemd unit files to reference current/ and shared/
+#   8. Reloads systemd and restarts services
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <app_name>"
+    echo "Example: $0 myapp"
+    exit 1
+fi
+
+APP_NAME="$1"
+APP_DIR="/opt/fujin/${APP_NAME}"
+INSTALL_DIR="${APP_DIR}/.install"
+
+if [ ! -d "$INSTALL_DIR" ]; then
+    echo "Error: ${INSTALL_DIR} not found. Is this app deployed with fujin?"
+    exit 1
+fi
+
+if [ -d "${APP_DIR}/releases" ] || [ -L "${APP_DIR}/current" ]; then
+    echo "Error: ${APP_DIR} already appears to be using the new structure (releases/ or current exists)."
+    echo "Migration has already been applied or the app was deployed with a newer fujin version."
+    exit 1
+fi
+
+# Read current version
+CURRENT_VERSION=$(cat "${INSTALL_DIR}/.version" 2>/dev/null || echo "")
+if [ -z "$CURRENT_VERSION" ]; then
+    echo "Error: Could not read version from ${INSTALL_DIR}/.version"
+    exit 1
+fi
+echo "Migrating ${APP_NAME} (version ${CURRENT_VERSION})..."
+
+# Create new directories
+RELEASE_DIR="${APP_DIR}/releases/${CURRENT_VERSION}"
+SHARED_DIR="${APP_DIR}/shared"
+
+mkdir -p "${APP_DIR}/releases"
+mkdir -p "$SHARED_DIR"
+
+# Stop services before migration
+echo "Stopping services..."
+systemctl stop "${APP_NAME}-*.service" 2>/dev/null || true
+
+# Move .env to shared/ (if it exists and is not already there)
+if [ -f "${INSTALL_DIR}/.env" ]; then
+    echo "Moving .env to shared/"
+    cp "${INSTALL_DIR}/.env" "${SHARED_DIR}/.env"
+    chmod 640 "${SHARED_DIR}/.env"
+fi
+
+# Move .install/ contents to releases/{version}/
+echo "Moving .install/ to releases/${CURRENT_VERSION}/"
+if [ -d "$RELEASE_DIR" ]; then
+    echo "Warning: ${RELEASE_DIR} already exists, removing..."
+    rm -rf "$RELEASE_DIR"
+fi
+mv "$INSTALL_DIR" "$RELEASE_DIR"
+
+# Remove old .versions/ directory if it was inside .install/
+if [ -d "${RELEASE_DIR}/.versions" ]; then
+    echo "Removing old .versions/ directory (no longer needed)..."
+    rm -rf "${RELEASE_DIR}/.versions"
+fi
+
+# Create current symlink
+echo "Creating current -> releases/${CURRENT_VERSION} symlink..."
+ln -sfn "releases/${CURRENT_VERSION}" "${APP_DIR}/current"
+
+# Update .appenv to source from shared/.env instead of release/.env or install/.env
+APPENV="${RELEASE_DIR}/.appenv"
+if [ -f "$APPENV" ]; then
+    echo "Updating .appenv to reference shared/.env..."
+    sed -i "s|source ${INSTALL_DIR}/.env|source ${SHARED_DIR}/.env|g" "$APPENV"
+    sed -i "s|source ${RELEASE_DIR}/.env|source ${SHARED_DIR}/.env|g" "$APPENV"
+fi
+
+# Update systemd unit files to use new paths
+echo "Updating systemd unit files..."
+for unit_file in /etc/systemd/system/"${APP_NAME}"*.service; do
+    if [ -f "$unit_file" ]; then
+        echo "  Updating ${unit_file}..."
+        # Replace .install/ paths with current/ and shared/
+        sed -i "s|${APP_DIR}/\.install/\.venv|${APP_DIR}/current/.venv|g" "$unit_file"
+        sed -i "s|${APP_DIR}/\.install/\([^/]\)|${APP_DIR}/current/\1|g" "$unit_file"
+        sed -i "s|EnvironmentFile=${APP_DIR}/\.install/\.env|EnvironmentFile=${SHARED_DIR}/.env|g" "$unit_file"
+        sed -i "s|EnvironmentFile=-${APP_DIR}/\.install/\.env|EnvironmentFile=-${SHARED_DIR}/.env|g" "$unit_file"
+    fi
+done
+
+for socket_file in /etc/systemd/system/"${APP_NAME}"*.socket; do
+    if [ -f "$socket_file" ]; then
+        echo "  Updating ${socket_file}..."
+        sed -i "s|${APP_DIR}/\.install/|${APP_DIR}/current/|g" "$socket_file"
+    fi
+done
+
+# Reload systemd
+echo "Reloading systemd..."
+systemctl daemon-reload
+
+# Restart services
+echo "Starting services..."
+systemctl restart "${APP_NAME}-*.service" 2>/dev/null || systemctl start "${APP_NAME}-*.service" 2>/dev/null || true
+
+echo ""
+echo "Migration complete!"
+echo "  App directory: ${APP_DIR}"
+echo "  Current version: ${CURRENT_VERSION}"
+echo "  New structure:"
+echo "    ${APP_DIR}/current -> releases/${CURRENT_VERSION}/"
+echo "    ${APP_DIR}/releases/${CURRENT_VERSION}/"
+echo "    ${APP_DIR}/shared/.env"
+echo ""
+echo "  Verify with: systemctl status ${APP_NAME}-*.service"
+echo "  Next deploy will use the new structure automatically."

--- a/src/fujin/_installer.py
+++ b/src/fujin/_installer.py
@@ -53,6 +53,7 @@ class InstallConfig:
     app_user: str
     deploy_user: str
     app_dir: str
+    shared_dir: str
     version: str
     installation_mode: Literal["python-package", "binary"]
     python_version: str | None
@@ -63,6 +64,7 @@ class InstallConfig:
     app_bin: str
     deployed_units: list[DeployedUnit]
     hooks: dict[str, list[str]] = field(default_factory=dict)
+    versions_to_keep: int = 3
 
     @property
     def uv_path(self) -> str:
@@ -103,17 +105,18 @@ def _setup_logging(verbose: int) -> None:
     logger.setLevel(level)
 
 
-def _run_hooks(config: InstallConfig, phase: str, *, fatal: bool = True) -> None:
+def _run_hooks(
+    config: InstallConfig, phase: str, source_dir: str, *, fatal: bool = True
+) -> None:
     commands = config.hooks.get(phase, [])
     if not commands:
         return
 
     logger.info("Running %s hooks...", phase)
-    install_dir = f"{config.app_dir}/.install"
     for cmd in commands:
         logger.info("  [%s] %s", phase, cmd)
         full_cmd = f"sudo -u {shlex.quote(config.app_user)} bash -c " + shlex.quote(
-            f"source {install_dir}/.appenv 2>/dev/null ; {cmd}"
+            f"source {source_dir}/.appenv 2>/dev/null ; {cmd}"
         )
         try:
             run(full_cmd, check=True, timeout=300)
@@ -130,8 +133,12 @@ def _run_hooks(config: InstallConfig, phase: str, *, fatal: bool = True) -> None
 def install(
     config: InstallConfig, bundle_dir: Path, *, full_restart: bool = False
 ) -> None:
-    """Install the application.
-    Assumes it's running from a directory with extracted bundle files.
+    """Install the application using release-based atomic deployment.
+
+    The new version is built in a self-contained release directory.
+    On success, a 'current' symlink is atomically swapped to activate it.
+    On failure, the release directory is cleaned up and the old version
+    keeps running untouched.
     """
 
     # ==========================================================================
@@ -143,41 +150,42 @@ def install(
         logger.debug("User %s already exists", config.app_user)
     except KeyError:
         logger.debug("Creating system user: %s", config.app_user)
-        # Check if group already exists (e.g., from a previous partial install)
         try:
             grp.getgrnam(config.app_user)
-            # Group exists, use it instead of creating a new one
             useradd_cmd = f"useradd --system --no-create-home --shell /usr/sbin/nologin --no-user-group -g {config.app_user} {config.app_user}"
         except KeyError:
-            # No existing group, let useradd create one
             useradd_cmd = f"useradd --system --no-create-home --shell /usr/sbin/nologin {config.app_user}"
         run(useradd_cmd, check=True)
 
     app_dir = Path(config.app_dir)
     app_dir.mkdir(parents=True, exist_ok=True)
-    logger.debug("Created app directory: %s", app_dir)
+    shared_dir = Path(config.shared_dir)
+    shared_dir.mkdir(exist_ok=True)
 
-    install_dir = app_dir / ".install"
-    install_dir.mkdir(exist_ok=True)
+    release_dir = Path(config.app_dir) / "releases" / config.version
+    if release_dir.exists():
+        logger.info("Cleaning up previous partial release: %s", release_dir)
+        shutil.rmtree(release_dir)
+    release_dir.mkdir(parents=True)
 
     # ==========================================================================
     # PHASE 2: INSTALLATION
     # ==========================================================================
-    logger.info("Installing application...")
+    logger.info("Installing application into %s ...", release_dir)
+    install_dir = release_dir
     os.chdir(install_dir)
 
     # record app version
     (install_dir / ".version").write_text(config.version)
-    logger.debug("Recorded version: %s", config.version)
 
     service_helpers = _format_service_helpers(config)
+    uv_python_install_dir = "UV_PYTHON_INSTALL_DIR=/opt/fujin/.python"
+
     if config.installation_mode == "python-package":
         logger.debug("Installation mode: python-package")
 
-        uv_python_install_dir = "UV_PYTHON_INSTALL_DIR=/opt/fujin/.python"
-
         (install_dir / ".appenv").write_text(f"""set -a
-source {install_dir}/.env
+source {shared_dir}/.env
 set +a
 export {uv_python_install_dir}
 export PATH="{install_dir}/.venv/bin:$PATH"
@@ -203,8 +211,6 @@ export -f {config.app_name}
             logger.debug("Virtual environment already exists")
 
         logger.debug("Installing package: %s", config.distfile_name)
-        # Combine distfile + requirements into a single uv invocation.
-        # --no-deps applies to the distfile; -r installs deps from requirements.
         install_cmd = (
             f"UV_COMPILE_BYTECODE=1 {uv_python_install_dir} "
             f"{config.uv_path} pip install {distfile_path} --no-deps"
@@ -216,7 +222,7 @@ export -f {config.app_name}
     else:
         logger.debug("Installation mode: binary")
         (install_dir / ".appenv").write_text(f"""set -a
-source {install_dir}/.env
+source {shared_dir}/.env
 set +a
 export PATH="{install_dir}:$PATH"
 
@@ -235,26 +241,26 @@ export -f {config.app_name}
 
     logger.info("Setting file ownership and permissions...")
     logger.debug("Setting ownership to %s:%s", config.deploy_user, config.app_user)
-    # Only chown the .install directory - leave app runtime data untouched
     run(f"chown -R {config.deploy_user}:{config.app_user} {install_dir}")
-    # Make .install directory group-writable (deploy user can update, app user can read)
     install_dir.chmod(0o775)
 
-    # .venv permissions: readable/executable by group, writable by owner
-    # Use chmod -R with symbolic modes to traverse once instead of 3 find commands
     if (install_dir / ".venv").exists():
         logger.debug("Setting venv permissions")
         run(
             f"chmod -R u+rwX,go+rX {install_dir}/.venv && chmod -R u+x {install_dir}/.venv/bin"
         )
-    # Ensure app_dir itself is group-writable so app can create files
     run(f"chown {config.deploy_user}:{config.app_user} {app_dir}")
     app_dir.chmod(0o775)
 
     # ==========================================================================
     # PHASE 2.5: POST-INSTALL HOOKS
     # ==========================================================================
-    _run_hooks(config, "post_install", fatal=True)
+    try:
+        _run_hooks(config, "post_install", str(release_dir), fatal=True)
+    except Exception:
+        logger.error("Post-install hooks failed, cleaning up release...")
+        shutil.rmtree(release_dir)
+        raise
 
     # ==========================================================================
     # PHASE 3: CONFIGURING SYSTEMD SERVICES
@@ -276,18 +282,15 @@ export -f {config.app_name}
     ]
     logger.debug("Found %d existing unit files", len(installed_units))
 
-    # Clean up stale units - batch operations for efficiency
     stale_units = [u for u in installed_units if u not in valid_units]
     if stale_units:
         logger.debug("Removing %d stale units", len(stale_units))
-        # Separate template units (can't use --now) from regular units
         template_stale = [u for u in stale_units if u.endswith("@.service")]
         regular_stale = [u for u in stale_units if not u.endswith("@.service")]
         if regular_stale:
             run(f"systemctl disable --now --quiet {' '.join(regular_stale)}")
         if template_stale:
             run(f"systemctl disable --quiet {' '.join(template_stale)}")
-        # Reset failed state for all stale units at once
         run(f"systemctl reset-failed {' '.join(stale_units)}", capture_output=True)
 
     for search_dir in [SYSTEMD_SYSTEM_DIR, SYSTEMD_WANTS_DIR]:
@@ -325,7 +328,7 @@ export -f {config.app_name}
             timer_deployed_path.write_text(timer_content)
             logger.debug("Wrote %s", timer_deployed_path.name)
 
-    # Deploy common dropins (apply to all services)
+    # Deploy common dropins
     common_dir = systemd_dir / "common.d"
     if common_dir.exists():
         common_dropins = list(common_dir.glob("*.conf"))
@@ -339,21 +342,17 @@ export -f {config.app_name}
                 dropin_dest = dropin_dir / dropin_path.name
                 dropin_dest.write_text(dropin_content)
                 logger.debug(
-                    "Wrote common dropin %s to %s",
-                    dropin_path.name,
-                    dropin_dir.name,
+                    "Wrote common dropin %s to %s", dropin_path.name, dropin_dir.name
                 )
 
     # Deploy service-specific dropins
     for service_dropin_dir_path in systemd_dir.glob("*.service.d"):
         service_file_name = service_dropin_dir_path.name.removesuffix(".d")
-
         matching_unit = None
         for unit in config.deployed_units:
             if unit["service_file"] == service_file_name:
                 matching_unit = unit
                 break
-
         if matching_unit:
             deployed_dropin_dir = (
                 SYSTEMD_SYSTEM_DIR / f"{matching_unit['template_service_name']}.d"
@@ -371,24 +370,7 @@ export -f {config.app_name}
                 dropin_dest.write_text(dropin_content)
                 logger.debug("Wrote dropin %s", dropin_path.name)
 
-    logger.info("Restarting services...")
-    active_units = []
-    oneshot_units = _get_oneshot_units(config.deployed_units)
-    if oneshot_units:
-        logger.info(
-            "Skipping restart of Type=oneshot units: %s",
-            ", ".join(sorted(oneshot_units)),
-        )
-    for unit in config.deployed_units:
-        if unit["template_service_name"] not in oneshot_units:
-            active_units.extend(unit["service_instances"])
-        if unit["template_socket_name"]:
-            active_units.append(unit["template_socket_name"])
-        if unit["template_timer_name"]:
-            active_units.append(unit["template_timer_name"])
-
-    # Validate all unit files before enabling/starting (catch errors early).
-    # systemd-analyze accepts multiple paths and reports which files have issues.
+    # Validate all unit files before enabling/starting.
     unit_paths = [
         SYSTEMD_SYSTEM_DIR / unit["template_service_name"]
         for unit in config.deployed_units
@@ -410,6 +392,26 @@ export -f {config.app_name}
             for line in result.stderr.splitlines():
                 logger.warning("  %s", line)
 
+    # ==========================================================================
+    # PHASE 4: ATOMIC SWAP + RESTART
+    # ==========================================================================
+
+    logger.info("Activating new release...")
+    active_units = []
+    oneshot_units = _get_oneshot_units(config.deployed_units)
+    if oneshot_units:
+        logger.info(
+            "Skipping restart of Type=oneshot units: %s",
+            ", ".join(sorted(oneshot_units)),
+        )
+    for unit in config.deployed_units:
+        if unit["template_service_name"] not in oneshot_units:
+            active_units.extend(unit["service_instances"])
+        if unit["template_socket_name"]:
+            active_units.append(unit["template_socket_name"])
+        if unit["template_timer_name"]:
+            active_units.append(unit["template_timer_name"])
+
     if not active_units:
         run("systemctl daemon-reload")
         restart_result = run("true")
@@ -419,14 +421,19 @@ export -f {config.app_name}
             f"systemctl daemon-reload && systemctl enable {units_str}",
             check=True,
         )
+        # Atomic symlink swap: create temp symlink, then rename over current.
+        # os.rename() is atomic on the same filesystem.
+        current_link = app_dir / "current"
+        tmp_link = app_dir / ".current.tmp"
+        tmp_link.unlink(missing_ok=True)
+        tmp_link.symlink_to(release_dir)
+        tmp_link.rename(current_link)
+        logger.info("Switched current -> releases/%s", config.version)
 
         restart_cmd = "restart" if full_restart else "reload-or-restart"
-        restart_result = run(
-            f"systemctl {restart_cmd} {units_str}",
-        )
+        restart_result = run(f"systemctl {restart_cmd} {units_str}")
 
-    # Check if services are actually running (not just restart command succeeded)
-    # Only check services with no timer or socket - they should run immediately
+    # Health check for services that should be running immediately
     units_to_check = [
         unit["service_instances"]
         for unit in config.deployed_units
@@ -435,16 +442,11 @@ export -f {config.app_name}
     ]
     units_to_check = list(chain.from_iterable(units_to_check))
 
-    # Poll for service status with short intervals instead of fixed sleep
-    # Services that crash immediately may appear "active" briefly before systemd detects failure
-    # Use is-failed instead of is-active to correctly handle oneshot services,
-    # which transition to "inactive" after successful completion.
     failed_units = []
     if units_to_check:
         max_attempts = 10
         poll_interval = 0.3
         for attempt in range(max_attempts):
-            # Batch check all units at once - systemctl is-failed returns one status per line
             status_result = run(
                 f"systemctl is-failed {' '.join(units_to_check)}",
                 capture_output=True,
@@ -457,7 +459,6 @@ export -f {config.app_name}
             ]
             if not failed_units:
                 break
-            # If we still have failures, wait a bit and retry (services may be starting)
             if attempt < max_attempts - 1:
                 time.sleep(poll_interval)
 
@@ -468,81 +469,71 @@ export -f {config.app_name}
             print("=" * 60)
             logger.error("%s failed to start", unit)
             print("=" * 60)
-            # This checks for syntax errors or missing dependencies defined in the unit file
             unit_path = SYSTEMD_SYSTEM_DIR / unit
             if unit_path.exists():
                 logger.error("Checking systemd unit configuration...")
-                # Always show output for failed services - don't suppress
                 subprocess.run(
                     f"systemd-analyze verify {shlex.quote(str(unit_path))}",
                     shell=True,
                 )
             else:
                 logger.error("Unit file not found at %s", unit_path)
-
-            # Show last 30 lines of logs for this unit
             logger.error("Recent logs:")
-            subprocess.run(
-                f"journalctl -u {unit} -n 30 --no-pager",
-                shell=True,
-            )
+            subprocess.run(f"journalctl -u {unit} -n 30 --no-pager", shell=True)
         sys.exit(EXIT_SERVICE_START_FAILED)
 
     # ==========================================================================
-    # PHASE 3.5: POST-START HOOKS
+    # PHASE 5: POST-START HOOKS + CADDY
     # ==========================================================================
-    _run_hooks(config, "post_start", fatal=False)
+    _run_hooks(config, "post_start", str(app_dir / "current"), fatal=False)
 
-    # ==========================================================================
-    # PHASE 4: CADDY CONFIGURATION
-    # ==========================================================================
-    # Configure Caddy after services are running successfully
+    # Prune old releases (keep last N, ordered by modification time)
+    releases_dir_path = Path(config.app_dir) / "releases"
+    all_releases = sorted(
+        [d for d in releases_dir_path.iterdir() if d.is_dir()],
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if len(all_releases) > config.versions_to_keep:
+        for old_dir in all_releases[: -config.versions_to_keep]:
+            if old_dir.name != config.version:  # don't prune what we just installed
+                logger.info("Pruning old release: %s", old_dir.name)
+                shutil.rmtree(old_dir)
+
+    # Caddy configuration
     if config.webserver_enabled:
         caddyfile_path = bundle_dir / "Caddyfile"
         if caddyfile_path.exists():
             logger.info("Configuring Caddy...")
-
             caddy_config_path = Path(config.caddy_config_path)
-
-            # Backup existing config if it exists
             old_config_content = None
             if caddy_config_path.exists():
                 old_config_content = caddy_config_path.read_text()
-
-            # Copy new config
             shutil.copy2(caddyfile_path, caddy_config_path)
             uid = pwd.getpwnam("caddy").pw_uid
             gid = grp.getgrnam("caddy").gr_gid
             os.chown(caddy_config_path, uid, gid)
-
             logger.debug("Reloading Caddy")
             try:
                 reload_result = run(
-                    "systemctl reload caddy",
-                    timeout=20,
-                    capture_output=True,
+                    "systemctl reload caddy", timeout=20, capture_output=True
                 )
                 reload_failed = reload_result.returncode != 0
             except subprocess.TimeoutExpired:
                 reload_failed = True
                 logger.warning("Caddy reload timeout")
-
             if reload_failed:
                 logger.warning("Caddy reload failed")
-                # Always show Caddy logs on failure - don't suppress
                 logger.warning("Recent Caddy logs:")
                 subprocess.run(
-                    "journalctl -u caddy.service -n 15 --no-pager",
-                    shell=True,
+                    "journalctl -u caddy.service -n 15 --no-pager", shell=True
                 )
-
                 if old_config_content:
                     logger.warning("Restoring previous Caddy configuration")
                     caddy_config_path.write_text(old_config_content)
                 else:
                     logger.warning("Removing invalid Caddy configuration")
                     caddy_config_path.unlink(missing_ok=True)
-
                 logger.warning(
                     "App is running but Caddy configuration failed. "
                     "Fix your Caddyfile and redeploy."
@@ -596,6 +587,12 @@ def uninstall(config: InstallConfig, bundle_dir: Path) -> None:
         Path(config.caddy_config_path).unlink(missing_ok=True)
         logger.debug("Reloading Caddy")
         run("systemctl reload caddy")
+
+    # Remove app directory (releases, shared, current symlink)
+    app_dir = Path(config.app_dir)
+    logger.info("Removing app directory: %s", app_dir)
+    if app_dir.exists():
+        shutil.rmtree(app_dir)
 
     logger.info("Deleting app user...")
     try:
@@ -720,7 +717,7 @@ def main() -> None:
 def _format_service_helpers(config: InstallConfig) -> str:
     """Format service management helpers with config values."""
     valid_services = " ".join(u["name"] for u in config.deployed_units)
-    install_dir = f"{config.app_dir}/.install"
+    current_dir = f"{config.app_dir}/current"
 
     helpers = service_management_helpers.format(
         app_name=config.app_name,
@@ -729,7 +726,7 @@ def _format_service_helpers(config: InstallConfig) -> str:
     )
 
     if config.installation_mode == "python-package":
-        helpers += python_package_helpers.format(install_dir=install_dir)
+        helpers += python_package_helpers.format(current_dir=current_dir)
 
     return helpers
 
@@ -812,13 +809,13 @@ edit() {{
     echo "⚠️  Warning: Changes will be lost on next deploy" >&2
     local target="${{1:-}}"
     local site_packages
-    site_packages=$({install_dir}/.venv/bin/python -c "import site; print(site.getsitepackages()[0])")
+    site_packages=$({current_dir}/.venv/bin/python -c "import site; print(site.getsitepackages()[0])")
 
     if [[ -z "$target" ]]; then
         ${{EDITOR:-${{VISUAL:-vi}}}} "$site_packages"
     else
         local pkg_path
-        pkg_path=$({install_dir}/.venv/bin/python -c "import $target, os; print(os.path.dirname($target.__file__))" 2>/dev/null)
+        pkg_path=$({current_dir}/.venv/bin/python -c "import $target, os; print(os.path.dirname($target.__file__))" 2>/dev/null)
         if [[ -n "$pkg_path" ]]; then
             ${{EDITOR:-${{VISUAL:-vi}}}} "$pkg_path"
         else

--- a/src/fujin/commands/app.py
+++ b/src/fujin/commands/app.py
@@ -57,7 +57,7 @@ class App(BaseCommand):
 
         with connection.connection(host=self.selected_host) as conn:
             shlex.quote(self.config.app_dir)
-            fujin_dir = shlex.quote(self.config.install_dir)
+            fujin_dir = shlex.quote(f"{self.config.app_dir}/current")
             remote_version, _ = conn.run(
                 f"cat {fujin_dir}/.version 2>/dev/null || echo N/A",
                 warn=True,
@@ -248,7 +248,7 @@ class App(BaseCommand):
             ssh_cmd.extend(["-i", str(host.key_filename)])
 
         full_remote_cmd = (
-            f"cd {self.config.app_dir} && source .install/.appenv && {command}"
+            f"cd {self.config.app_dir} && source current/.appenv && {command}"
         )
         ssh_cmd.extend([ssh_target, full_remote_cmd])
         subprocess.run(ssh_cmd)
@@ -259,7 +259,7 @@ class App(BaseCommand):
         command: Annotated[str, cappa.Arg(help="Command to execute")],
     ):
         with connection.connection(host=self.selected_host) as conn:
-            cmd = f"cd {self.config.app_dir} && source .install/.appenv && {self.config.app_bin} {command}"
+            cmd = f"cd {self.config.app_dir} && source current/.appenv && {self.config.app_bin} {command}"
             conn.run(
                 f"sudo -u {self.config.app_user} bash -c {shlex.quote(cmd)}",
                 pty=True,
@@ -435,7 +435,7 @@ class App(BaseCommand):
                 return
 
             if name == "env":
-                fujin_dir = shlex.quote(self.config.install_dir)
+                fujin_dir = shlex.quote(self.config.shared_dir)
                 env_path = f"{fujin_dir}/.env"
                 self.output.output(f"[cyan]# {env_path}[/cyan]")
                 print()

--- a/src/fujin/commands/deploy.py
+++ b/src/fujin/commands/deploy.py
@@ -170,7 +170,7 @@ class Deploy(BaseCommand):
                 "app_user": self.config.app_user,
                 "version": version,
                 "app_dir": self.config.app_dir,
-                "install_dir": self.config.install_dir,
+                "shared_dir": self.config.shared_dir,
                 "user": self.selected_host.user,
             }
 
@@ -323,6 +323,7 @@ class Deploy(BaseCommand):
                 "app_user": self.config.app_user,
                 "deploy_user": self.selected_host.user,
                 "app_dir": self.config.app_dir,
+                "shared_dir": self.config.shared_dir,
                 "version": bundle_version,
                 "installation_mode": self.config.installation_mode.value,
                 "python_version": self.config.python_version,
@@ -330,9 +331,10 @@ class Deploy(BaseCommand):
                 "distfile_name": distfile_path.name,
                 "webserver_enabled": self.config.caddyfile_exists,
                 "caddy_config_path": self.config.caddy_config_path,
-                "app_bin": self.config.app_name,  # Just the binary name, not full path
+                "app_bin": self.config.app_name,
                 "deployed_units": deployed_units_data,
                 "hooks": resolved_hooks,
+                "versions_to_keep": self.config.versions_to_keep or 3,
             }
 
             # Write config without indent for smaller size
@@ -350,53 +352,35 @@ class Deploy(BaseCommand):
             bundle_size = zipapp_path.stat().st_size
             self._show_deployment_summary(bundle_size, bundle_version)
 
-            remote_bundle_dir = Path(self.config.install_dir) / ".versions"
             remote_bundle_path = (
-                f"{remote_bundle_dir}/{self.config.app_name}-{bundle_version}.pyz"
+                f"/tmp/fujin-{self.config.app_name}-{bundle_version}.pyz"
             )
+            remote_bundle_path_q = shlex.quote(remote_bundle_path)
 
-            # Quote remote paths for shell usage (safe insertion into remote commands)
-            remote_bundle_dir_q = shlex.quote(str(remote_bundle_dir))
-            remote_bundle_path_q = shlex.quote(str(remote_bundle_path))
-
-            # Minimum size threshold for rsync (30MB) - below this, overhead isn't worth it
+            # Minimum size threshold for rsync (30MB) — below this, overhead isn't worth it
             min_rsync_size = 30 * 1024 * 1024
 
             # Upload and Execute
             with self._deploy_session() as conn:
-                # Check rsync availability while creating the directory (single round trip)
-                # Only check if bundle is large enough to benefit from rsync
+                # Check rsync availability (single round trip)
+                use_rsync = False
                 if bundle_size >= min_rsync_size:
-                    output, _ = conn.run(
-                        f"mkdir -p {remote_bundle_dir_q} > /dev/null && command -v rsync",
-                        warn=True,
-                        hide=True,
-                    )
+                    output, _ = conn.run("command -v rsync", warn=True, hide=True)
                     use_rsync = bool(output.strip())
-                else:
-                    conn.run(f"mkdir -p {remote_bundle_dir_q}", hide=True)
-                    use_rsync = False
 
                 self.output.info("Uploading deployment bundle...")
-                # rsync uses staging file for delta transfer benefits from prior deploys
                 if use_rsync:
-                    staging_path = f"{remote_bundle_dir}/.staging.pyz"
+                    staging_path = "/tmp/.fujin-staging.pyz"
                     staging_path_q = shlex.quote(staging_path)
-                    logger.debug("Using rsync for upload")
+                    logger.debug("Using rsync for delta upload")
                     try:
                         conn.rsync_upload(str(zipapp_path), staging_path_q)
-                        # Copy staging to final path (preserves staging for next deploy's delta)
                         conn.run(
                             f"cp -f {staging_path_q} {remote_bundle_path_q}",
                             hide=True,
                         )
-                    except FileNotFoundError:
-                        self.output.warning(
-                            "rsync not found locally, falling back to SCP"
-                        )
-                        use_rsync = False
-                    except UploadError as e:
-                        self.output.warning(f"rsync failed: {e}, falling back to SCP")
+                    except (FileNotFoundError, UploadError) as e:
+                        self.output.warning(f"rsync failed ({e}), falling back to SCP")
                         use_rsync = False
 
                 if not use_rsync:
@@ -407,16 +391,16 @@ class Deploy(BaseCommand):
 
                 self.output.info("Executing remote installation...")
 
-                # Write .env file directly (not bundled for security)
-                remote_env_path = f"{self.config.install_dir}/.env"
+                # Write .env file to shared/ (persistent across releases)
+                remote_env_path = f"{self.config.shared_dir}/.env"
                 remote_env_path_q = shlex.quote(remote_env_path)
-                install_dir_q = shlex.quote(self.config.install_dir)
+                shared_dir_q = shlex.quote(self.config.shared_dir)
                 remote_env_backup_q = shlex.quote(f"{remote_env_path}.bak")
                 logger.debug("Writing .env to %s", remote_env_path)
 
-                # Backup existing .env (ensure install dir exists first)
+                # Backup existing .env (ensure shared dir exists first)
                 conn.run(
-                    f"mkdir -p {install_dir_q} && "
+                    f"mkdir -p {shared_dir_q} && "
                     f"cp {remote_env_path_q} {remote_env_backup_q} 2>/dev/null || true",
                     hide=True,
                 )
@@ -456,7 +440,7 @@ class Deploy(BaseCommand):
                         for cmd in pre_install_commands:
                             self.output.info(f"  [pre-install] {cmd}")
                             full_cmd = (
-                                f"set -a; source {install_dir_q}/.env 2>/dev/null; set +a; "
+                                f"set -a; source {shared_dir_q}/.env 2>/dev/null; set +a; "
                                 f"{cmd}"
                             )
                             conn.run(full_cmd, pty=True)
@@ -520,16 +504,8 @@ class Deploy(BaseCommand):
                         self.output.info("Removing failed deployment bundle...")
                         conn.run(f"rm -f {remote_bundle_path_q}", warn=True)
 
-                if self.config.versions_to_keep and not rollback_ran:
-                    self.output.info("Pruning old versions...")
-                    logger.debug("Keeping %d versions", self.config.versions_to_keep)
-                    conn.run(
-                        f"cd {remote_bundle_dir_q} && "
-                        f"ls -1t | tail -n +{self.config.versions_to_keep + 1} | xargs -r rm",
-                        warn=True,
-                    )
-
                 if not rollback_ran:
+                    conn.run(f"rm -f {remote_bundle_path_q}", warn=True, hide=True)
                     conn.run(f"rm -f {remote_env_backup_q}", warn=True, hide=True)
 
                 # Get git commit hash if available
@@ -579,10 +555,10 @@ class Deploy(BaseCommand):
         connection, and releases it on exit (even on error).
         """
         with connection.connection(host=self.selected_host, compress=False) as conn:
-            install_dir_q = shlex.quote(self.config.install_dir)
-            lock_file_q = shlex.quote(f"{self.config.install_dir}/.deploy_lock")
+            app_dir_q = shlex.quote(self.config.app_dir)
+            lock_file_q = shlex.quote(f"{self.config.app_dir}/.deploy_lock")
             _, acquired = conn.run(
-                f"mkdir -p {install_dir_q} && (set -C; echo $$ > {lock_file_q}) 2>/dev/null",
+                f"mkdir -p {app_dir_q} && (set -C; echo $$ > {lock_file_q}) 2>/dev/null",
                 warn=True,
                 hide=True,
             )

--- a/src/fujin/commands/down.py
+++ b/src/fujin/commands/down.py
@@ -26,13 +26,6 @@ class Down(BaseCommand):
             help="Stop and uninstall proxy as part of teardown",
         ),
     ] = False
-    force: Annotated[
-        bool,
-        cappa.Arg(
-            long="--force",
-            help="Continue teardown even if uninstall script fails",
-        ),
-    ] = False
 
     def __call__(self):
         msg = (
@@ -52,30 +45,28 @@ class Down(BaseCommand):
         with connection.connection(host=self.selected_host) as conn:
             self.output.info("Tearing down project...")
 
-            app_dir = shlex.quote(self.config.app_dir)
-            install_dir = shlex.quote(self.config.install_dir)
-            res, ok = conn.run(f"cat {install_dir}/.version", warn=True, hide=True)
+            app_dir_q = shlex.quote(self.config.app_dir)
+            current_dir = shlex.quote(f"{self.config.app_dir}/current")
+            res, ok = conn.run(f"cat {current_dir}/.version", warn=True, hide=True)
             version = res.strip() if ok else self.config.version
-            bundle_path = (
-                f"{install_dir}/.versions/{self.config.app_name}-{version}.pyz"
+
+            # Stop and remove systemd units, Caddy config, then remove app directory
+            conn.run(
+                f"systemctl stop {self.config.app_name}-*.service 2>/dev/null; "
+                f"systemctl disable {self.config.app_name}-* 2>/dev/null; "
+                f"rm -f /etc/systemd/system/{self.config.app_name}-*; "
+                f"systemctl daemon-reload; "
+                f"rm -f /etc/caddy/conf.d/{self.config.app_name}.caddy; "
+                f"systemctl reload caddy 2>/dev/null; "
+                f"rm -rf {app_dir_q}",
+                warn=True,
+                pty=True,
             )
 
-            _, bundle_exists = conn.run(f"test -f {bundle_path}", warn=True, hide=True)
-
-            uninstall_ok = False
-            if bundle_exists:
-                verbose_flag = f" --verbose {self.verbose}" if self.verbose > 0 else ""
-                uninstall_cmd = f"sudo python3 {bundle_path} uninstall{verbose_flag} && sudo rm -rf {app_dir}"
-                _, uninstall_ok = conn.run(uninstall_cmd, warn=True, pty=True)
-
-            if not uninstall_ok:
-                if not self.force:
-                    raise cappa.Exit("Teardown failed", code=1)
-
-                self.output.warning(
-                    "Teardown encountered errors but continuing due to --force"
-                )
-                conn.run(f"sudo rm -rf {app_dir}", warn=True, pty=True)
+            # Remove app user
+            conn.run(
+                f"userdel -r {self.config.app_user} 2>/dev/null || true", warn=True
+            )
 
             if self.full:
                 conn.run(

--- a/src/fujin/commands/init.py
+++ b/src/fujin/commands/init.py
@@ -143,8 +143,8 @@ class Init(BaseCommand):
         service_content = NEW_SERVICE_TEMPLATE.format(name="web")
         # Customize ExecStart for gunicorn
         service_content = service_content.replace(
-            "ExecStart={install_dir}/.venv/bin/python -m myapp.web",
-            f"ExecStart={{install_dir}}/.venv/bin/gunicorn {app_name}.wsgi:application --bind 0.0.0.0:8000",
+            "ExecStart={app_dir}/current/.venv/bin/python -m myapp.web",
+            f"ExecStart={{app_dir}}/current/.venv/bin/gunicorn {app_name}.wsgi:application --bind 0.0.0.0:8000",
         )
         web_service.write_text(service_content)
         self.output.success(f"  Created {web_service}")
@@ -163,8 +163,8 @@ class Init(BaseCommand):
         # Add ExecStartPre for migrations and collectstatic
         exec_start_pre_lines = (
             f"# Run migrations and collect static files before starting\n"
-            f"ExecStartPre={{install_dir}}/.venv/bin/{app_name} migrate\n"
-            f"ExecStartPre={{install_dir}}/.venv/bin/{app_name} collectstatic --no-input\n"
+            f"ExecStartPre={{app_dir}}/current/.venv/bin/{app_name} migrate\n"
+            f"ExecStartPre={{app_dir}}/current/.venv/bin/{app_name} collectstatic --no-input\n"
             f"ExecStartPre=/bin/bash -c 'rsync -a --delete staticfiles/ {{app_dir}}/staticfiles/'\n"
         )
         service_content = service_content.replace(
@@ -173,12 +173,12 @@ class Init(BaseCommand):
 
         # Customize ExecStart for gunicorn and add reload with migrations
         service_content = service_content.replace(
-            "ExecStart={install_dir}/.venv/bin/python -m myapp.web",
-            f"ExecStart={{install_dir}}/.venv/bin/gunicorn {app_name}.wsgi:application --bind 0.0.0.0:8000",
+            "ExecStart={app_dir}/current/.venv/bin/python -m myapp.web",
+            f"ExecStart={{app_dir}}/current/.venv/bin/gunicorn {app_name}.wsgi:application --bind 0.0.0.0:8000",
         )
         exec_reload_lines = (
-            f"ExecReload={{install_dir}}/.venv/bin/{app_name} migrate\n"
-            f"ExecReload={{install_dir}}/.venv/bin/{app_name} collectstatic --no-input\n"
+            f"ExecReload={{app_dir}}/current/.venv/bin/{app_name} migrate\n"
+            f"ExecReload={{app_dir}}/current/.venv/bin/{app_name} collectstatic --no-input\n"
             f"ExecReload=/bin/kill -s HUP $MAINPID\n"
         )
         service_content = service_content.replace(
@@ -209,7 +209,7 @@ class Init(BaseCommand):
 
         # Customize ExecStart for binary (no .venv)
         service_content = service_content.replace(
-            "ExecStart={install_dir}/.venv/bin/python -m myapp.web",
+            "ExecStart={app_dir}/current/.venv/bin/python -m myapp.web",
             f"ExecStart={{app_dir}}/{app_name} prodserver",
         )
         web_service.write_text(service_content)

--- a/src/fujin/commands/migrate.py
+++ b/src/fujin/commands/migrate.py
@@ -285,7 +285,7 @@ class Migrate(BaseCommand):
 
         # Customize ExecStart
         service_content = service_content.replace(
-            f"ExecStart={{install_dir}}/.venv/bin/python -m myapp.{name}",
+            f"ExecStart={{app_dir}}/current/.venv/bin/python -m myapp.{name}",
             f"ExecStart={{app_dir}}/{command}",
         )
 
@@ -304,12 +304,12 @@ class Migrate(BaseCommand):
                     if installation_mode == "python-package":
                         # Use python -m for python packages
                         full_cmd = (
-                            f"{{install_dir}}/.venv/bin/python -m {{app_name}}"
+                            f"{{app_dir}}/current/.venv/bin/python -m {{app_name}}"
                             + (f" {rest_of_cmd}" if rest_of_cmd else "")
                         )
                     else:
-                        # For binary mode, use {install_dir}/{app_name}
-                        full_cmd = f"{{install_dir}}/{{app_name}}" + (
+                        # For binary mode, use {app_dir}/current/{app_name}
+                        full_cmd = f"{{app_dir}}/current/{{app_name}}" + (
                             f" {rest_of_cmd}" if rest_of_cmd else ""
                         )
                 else:

--- a/src/fujin/commands/prune.py
+++ b/src/fujin/commands/prune.py
@@ -30,48 +30,36 @@ class Prune(BaseCommand):
         if keep < 1:
             raise cappa.Exit("The minimum value for the --keep option is 1", code=1)
 
-        versions_dir = f"{self.config.install_dir}/.versions"
+        releases_dir = f"{self.config.app_dir}/releases"
         with connection.connection(host=self.selected_host) as conn:
-            _, success = conn.run(f"test -d {versions_dir}", warn=True, hide=True)
+            _, success = conn.run(f"test -d {releases_dir}", warn=True, hide=True)
             if not success:
-                self.output.info("No versions directory found. Nothing to prune.")
+                self.output.info("No releases directory found. Nothing to prune.")
                 return
 
-            # List files sorted by time (newest first)
-            result, _ = conn.run(f"ls -1t {versions_dir}", warn=True, hide=True)
+            result, _ = conn.run(f"ls -1t {releases_dir}", warn=True, hide=True)
 
             if not result:
-                self.output.info("No versions found to prune")
+                self.output.info("No releases found to prune")
                 return
 
-            filenames = result.strip().splitlines()
-            prefix = f"{self.config.app_name}-"
-            suffix = ".pyz"
+            all_releases = [d for d in result.strip().splitlines() if d]
 
-            valid_bundles = []
-            for fname in filenames:
-                if fname.startswith(prefix) and fname.endswith(suffix):
-                    valid_bundles.append(fname)
-
-            if len(valid_bundles) <= keep:
+            if len(all_releases) <= keep:
                 self.output.info(
-                    f"Only {len(valid_bundles)} versions found. Nothing to prune (keep={keep})."
+                    f"Only {len(all_releases)} release(s) found. Nothing to prune (keep={keep})."
                 )
                 return
 
-            to_delete = valid_bundles[keep:]
-            # Extract versions for display
-            versions_to_delete = []
-            for fname in to_delete:
-                v = fname[len(prefix) : -len(suffix)]
-                versions_to_delete.append(v)
+            to_delete = all_releases[keep:]
 
             if not Confirm.ask(
-                f"[red]The following versions will be permanently deleted: {', '.join(versions_to_delete)}.\\n"
+                f"[red]The following releases will be permanently deleted: {', '.join(to_delete)}.\\n"
                 f"This action is irreversible. Are you sure you want to proceed?[/red]"
             ):
                 return
 
-            cmd = f"cd {versions_dir} && rm -f {' '.join(to_delete)}"
-            conn.run(cmd)
+            for d in to_delete:
+                conn.run(f"rm -rf {releases_dir}/{d}")
+
             self.output.success("Pruning completed successfully")

--- a/src/fujin/commands/rollback.py
+++ b/src/fujin/commands/rollback.py
@@ -37,27 +37,23 @@ class Rollback(BaseCommand):
 
     def __call__(self):
         with connection.connection(host=self.selected_host) as conn:
-            shlex.quote(self.config.app_dir)
-            fujin_dir = shlex.quote(self.config.install_dir)
+            app_dir_q = shlex.quote(self.config.app_dir)
+            releases_dir_q = shlex.quote(f"{self.config.app_dir}/releases")
+
+            # Read current version from symlink target
             result, _ = conn.run(
-                f"cat {fujin_dir}/.version 2>/dev/null; echo '---'; ls -1t {fujin_dir}/.versions",
+                f"readlink {app_dir_q}/current 2>/dev/null | xargs basename || echo ''; "
+                f"echo '---'; ls -1t {releases_dir_q} 2>/dev/null || true",
                 warn=True,
                 hide=True,
             )
 
             parts = result.split("---\n", 1)
             current_version = parts[0].strip()
-            filenames = parts[1].strip().splitlines() if len(parts) > 1 else []
+            dirnames = parts[1].strip().splitlines() if len(parts) > 1 else []
 
-            versions = []
-            prefix = f"{self.config.app_name}-"
-            for fname in filenames:
-                if fname.startswith(prefix) and fname.endswith(".pyz"):
-                    v = fname[len(prefix) : -4]
-                    versions.append(v)
-
-            # Filter out current version from choices
-            available_versions = [v for v in versions if v != current_version]
+            # All directory names in releases/ are version identifiers
+            available_versions = [d for d in dirnames if d and d != current_version]
 
             if not available_versions:
                 msg = "No previous versions available for rollback"
@@ -96,47 +92,37 @@ class Rollback(BaseCommand):
                 if not confirm:
                     return
 
-            # Uninstall current
-            if current_version:
-                self.output.info(f"Uninstalling current version {current_version}...")
-                current_bundle = f"{fujin_dir}/.versions/{self.config.app_name}-{current_version}.pyz"
-                _, exists = conn.run(f"test -f {current_bundle}", warn=True, hide=True)
-
-                if exists:
-                    verbose_flag = (
-                        f" --verbose {self.verbose}" if self.verbose > 0 else ""
-                    )
-                    uninstall_cmd = (
-                        f"sudo python3 {current_bundle} uninstall{verbose_flag}"
-                    )
-                    _, ok = conn.run(uninstall_cmd, warn=True)
-                    if not ok:
-                        self.output.warning(
-                            f"Warning: uninstall failed for version {current_version}."
-                        )
-                else:
-                    self.output.warning(
-                        f"Bundle for current version {current_version} not found. Skipping uninstall."
-                    )
-
-            # Install target
-            self.output.info(f"Installing version {version}...")
-            target_bundle = (
-                f"{fujin_dir}/.versions/{self.config.app_name}-{version}.pyz"
+            # Swap symlink to the selected release
+            release_dir_q = shlex.quote(f"{self.config.app_dir}/releases/{version}")
+            _, release_exists = conn.run(
+                f"test -d {release_dir_q}", warn=True, hide=True
             )
-            verbose_flag = f" --verbose {self.verbose}" if self.verbose > 0 else ""
-            install_cmd = f"sudo python3 {target_bundle} install{verbose_flag} || (echo 'install failed' >&2; exit 1)"
 
-            # delete all versions after new target
-            cleanup_cmd = (
-                f"cd {fujin_dir}/.versions && ls -1t | "
-                f"awk '/{self.config.app_name}-{version}\\.pyz/{{exit}} {{print}}' | "
-                "xargs -r rm"
+            if not release_exists:
+                self.output.error(
+                    f"Release directory for version {version} not found. "
+                    "It may have been pruned. Re-deploy the desired version instead."
+                )
+                return
+
+            self.output.info(f"Switching to release {version}...")
+            conn.run(
+                f"ln -sfn {release_dir_q} {app_dir_q}/.current.tmp && "
+                f"mv {app_dir_q}/.current.tmp {app_dir_q}/current",
             )
-            full_cmd = install_cmd + (
-                f" && echo '==> Cleaning up newer versions...' && {cleanup_cmd}"
+            conn.run(
+                f"systemctl daemon-reload && "
+                f"systemctl restart {self.config.app_name}-*.service",
+                pty=True,
             )
-            conn.run(full_cmd, pty=True)
+
+            # Remove releases newer than the target (they were deployed after it)
+            conn.run(
+                f"cd {releases_dir_q} && ls -1t | "
+                f"awk '/{version}/{{exit}} {{print}}' | "
+                "xargs -r rm -rf",
+                warn=True,
+            )
 
             log_operation(
                 connection=conn,

--- a/src/fujin/commands/server.py
+++ b/src/fujin/commands/server.py
@@ -340,7 +340,7 @@ class Server(BaseCommand):
         with connection.connection(host=self.selected_host) as conn:
             if not appenv:
                 return conn.run(command, pty=True)
-            cmd = f"cd {self.config.app_dir} && source .install/.appenv && {command}"
+            cmd = f"cd {self.config.app_dir} && source current/.appenv && {command}"
             conn.run(
                 f"sudo -u {self.config.app_user} bash -c {shlex.quote(cmd)}",
                 pty=True,

--- a/src/fujin/config.py
+++ b/src/fujin/config.py
@@ -130,9 +130,8 @@ class Config(msgspec.Struct, kw_only=True, dict=True):
 
     @property
     def app_bin(self) -> str:
-        if self.installation_mode == InstallationMode.PY_PACKAGE:
-            return f".install/.venv/bin/{self.app_name}"
-        return f".install/{self.app_name}"
+        """Application binary name (bare name, PATH set by .appenv)."""
+        return self.app_name
 
     @property
     def local_version(self) -> str:
@@ -144,9 +143,18 @@ class Config(msgspec.Struct, kw_only=True, dict=True):
         return f"{self.apps_dir}/{self.app_name}"
 
     @property
-    def install_dir(self) -> str:
-        """Get .install subdirectory path (deployment infrastructure)."""
-        return f"{self.app_dir}/.install"
+    def shared_dir(self) -> str:
+        """Shared directory for persistent data (.env, media, databases)."""
+        return f"{self.app_dir}/shared"
+
+    @property
+    def releases_dir(self) -> str:
+        """Directory containing versioned release directories."""
+        return f"{self.app_dir}/releases"
+
+    def release_dir(self, version: str) -> str:
+        """Path to a specific release directory."""
+        return f"{self.releases_dir}/{version}"
 
     def get_distfile_path(self, version: str | None = None) -> Path:
         version = version or self.version

--- a/src/fujin/templates.py
+++ b/src/fujin/templates.py
@@ -15,14 +15,14 @@ After=network.target
 Type=simple
 User={{app_user}}
 WorkingDirectory={{app_dir}}
-EnvironmentFile={{install_dir}}/.env
+EnvironmentFile={{app_dir}}/shared/.env
 RuntimeDirectory={{app_name}}
 RuntimeDirectoryMode=0755
 # Create files as group-writable
 UMask=0002
 
 # Main command - adjust to match your application
-ExecStart={{install_dir}}/.venv/bin/python -m myapp.{name}
+ExecStart={{app_dir}}/current/.venv/bin/python -m myapp.{name}
 
 # Restart policy
 Restart=on-failure
@@ -57,12 +57,12 @@ Description={{app_name}} {name} task
 Type=oneshot
 User={{app_user}}
 WorkingDirectory={{app_dir}}
-EnvironmentFile={{install_dir}}/.env
+EnvironmentFile={{app_dir}}/shared/.env
 # Create files as group-writable
 UMask=0002
 
 # Main command - this runs when triggered by the timer
-ExecStart={{install_dir}}/.venv/bin/python -m myapp.{name}
+ExecStart={{app_dir}}/current/.venv/bin/python -m myapp.{name}
 
 # Resource limits (uncomment to enable)
 # MemoryMax=512M

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -129,7 +129,7 @@ def read_file(container_name: str, path: str) -> str:
 def get_deployed_version(container_name: str, app_name: str) -> str:
     """Get currently deployed version of app."""
     stdout, ok = exec_in_container(
-        container_name, f"cat /opt/fujin/{app_name}/.install/.version"
+        container_name, f"cat /opt/fujin/{app_name}/current/.version"
     )
     assert ok, f"Could not read version for {app_name}"
     return stdout.strip()

--- a/tests/integration/test_app_management.py
+++ b/tests/integration/test_app_management.py
@@ -43,7 +43,7 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/mgmtapp
+ExecStart={app_dir}/current/mgmtapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -57,7 +57,7 @@ Description=Worker
 
 [Service]
 Type=simple
-ExecStart={install_dir}/mgmtapp
+ExecStart={app_dir}/current/mgmtapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -230,7 +230,7 @@ def test_app_introspection(deployed_app, vps_container, monkeypatch):
 
     stdout, success = exec_in_container(
         vps_container["name"],
-        "cat /opt/fujin/mgmtapp/.install/.env",
+        "cat /opt/fujin/mgmtapp/shared/.env",
     )
     assert success, f"Reading .env should succeed: {stdout}"
     # Note: .env file exists but may be empty for binary installations

--- a/tests/integration/test_full_deploy.py
+++ b/tests/integration/test_full_deploy.py
@@ -78,9 +78,9 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/myapp
+ExecStart={app_dir}/current/myapp
 WorkingDirectory={app_dir}
-EnvironmentFile=-{install_dir}/.env
+EnvironmentFile=-{app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -177,9 +177,9 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/.venv/bin/python3 -m http.server 8000
+ExecStart={app_dir}/current/.venv/bin/python3 -m http.server 8000
 WorkingDirectory={app_dir}
-EnvironmentFile=-{install_dir}/.env
+EnvironmentFile=-{app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -192,9 +192,9 @@ Description=Worker
 
 [Service]
 Type=simple
-ExecStart={install_dir}/.venv/bin/python3 -c 'import time; print("worker running"); time.sleep(99999)'
+ExecStart={app_dir}/current/.venv/bin/python3 -c 'import time; print("worker running"); time.sleep(99999)'
 WorkingDirectory={app_dir}
-EnvironmentFile=-{install_dir}/.env
+EnvironmentFile=-{app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -235,7 +235,7 @@ WantedBy=multi-user.target
     # Verify .env was deployed
     stdout, success = exec_in_container(
         vps_container["name"],
-        "cat /opt/fujin/testapp/.install/.env",
+        "cat /opt/fujin/testapp/shared/.env",
     )
     assert success and "DEBUG=true" in stdout, f".env not deployed correctly: {stdout}"
 
@@ -262,9 +262,9 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/webapp
+ExecStart={app_dir}/current/webapp
 WorkingDirectory={app_dir}
-EnvironmentFile=-{install_dir}/.env
+EnvironmentFile=-{app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -344,9 +344,9 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/rollapp
+ExecStart={app_dir}/current/rollapp
 WorkingDirectory={app_dir}
-EnvironmentFile=-{install_dir}/.env
+EnvironmentFile=-{app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -390,7 +390,7 @@ WantedBy=multi-user.target
     # Verify v1.0.0 is running
     stdout, success = exec_in_container(
         vps_container["name"],
-        "cat /opt/fujin/rollapp/.install/.version",
+        "cat /opt/fujin/rollapp/current/.version",
     )
     assert success and stdout == "1.0.0", f"Expected version 1.0.0, got: '{stdout}'"
 
@@ -403,7 +403,7 @@ WantedBy=multi-user.target
     # Verify v2.0.0 is running
     stdout, success = exec_in_container(
         vps_container["name"],
-        "cat /opt/fujin/rollapp/.install/.version",
+        "cat /opt/fujin/rollapp/current/.version",
     )
     assert success and stdout == "2.0.0", f"Expected version 2.0.0, got: '{stdout}'"
 
@@ -420,7 +420,7 @@ WantedBy=multi-user.target
     # Verify v1.0.0 is running again
     stdout, success = exec_in_container(
         vps_container["name"],
-        "cat /opt/fujin/rollapp/.install/.version",
+        "cat /opt/fujin/rollapp/current/.version",
     )
     assert success and stdout == "1.0.0", (
         f"Expected version 1.0.0 after rollback, got: '{stdout}'"
@@ -462,9 +462,9 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/downapp
+ExecStart={app_dir}/current/downapp
 WorkingDirectory={app_dir}
-EnvironmentFile=-{install_dir}/.env
+EnvironmentFile=-{app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -553,9 +553,9 @@ Description=Secret app
 
 [Service]
 Type=simple
-ExecStart={install_dir}/secretapp
+ExecStart={app_dir}/current/secretapp
 WorkingDirectory={app_dir}
-EnvironmentFile={install_dir}/.env
+EnvironmentFile={app_dir}/shared/.env
 Restart=always
 
 [Install]
@@ -599,7 +599,7 @@ STATIC_VALUE=no-secret-here
 
     # Verify .env file was deployed with resolved secrets
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/secretapp/.install/.env"
+        vps_container["name"], "cat /opt/fujin/secretapp/shared/.env"
     )
     assert success, f"Could not read .env file: {stdout}"
 
@@ -634,7 +634,7 @@ Description=Sequential deploy test
 
 [Service]
 Type=simple
-ExecStart={install_dir}/seqapp
+ExecStart={app_dir}/current/seqapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -677,7 +677,7 @@ WantedBy=multi-user.target
 
     # Verify v1.0.0 is deployed
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/seqapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/seqapp/current/.version"
     )
     assert success and stdout.strip() == "1.0.0"
 
@@ -691,13 +691,13 @@ WantedBy=multi-user.target
 
     # Verify v1.1.0 is now deployed
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/seqapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/seqapp/current/.version"
     )
     assert success and stdout.strip() == "1.1.0"
 
     # Verify bundle history exists (both versions available)
     stdout, success = exec_in_container(
-        vps_container["name"], "ls /opt/fujin/seqapp/.install/.versions/"
+        vps_container["name"], "ls /opt/fujin/seqapp/current/.versions/"
     )
     assert success
     assert "seqapp-1.0.0.pyz" in stdout, f"v1.0.0 bundle should exist: {stdout}"
@@ -713,13 +713,13 @@ WantedBy=multi-user.target
 
     # Verify v1.2.0 is now deployed
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/seqapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/seqapp/current/.version"
     )
     assert success and stdout.strip() == "1.2.0"
 
     # All three versions should be available for rollback
     stdout, success = exec_in_container(
-        vps_container["name"], "ls /opt/fujin/seqapp/.install/.versions/"
+        vps_container["name"], "ls /opt/fujin/seqapp/current/.versions/"
     )
     assert success
     assert "seqapp-1.0.0.pyz" in stdout
@@ -746,7 +746,7 @@ Description=Data persistence test
 
 [Service]
 Type=simple
-ExecStart={install_dir}/dataapp
+ExecStart={app_dir}/current/dataapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -817,7 +817,7 @@ WantedBy=multi-user.target
 
     # Verify new version is deployed
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/dataapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/dataapp/current/.version"
     )
     assert success and stdout.strip() == "1.1.0"
 
@@ -868,7 +868,7 @@ Description=Fail app test
 
 [Service]
 Type=simple
-ExecStart={install_dir}/failapp
+ExecStart={app_dir}/current/failapp
 WorkingDirectory={app_dir}
 Restart=no
 
@@ -886,7 +886,7 @@ WantedBy=multi-user.target
     # Verify v1.0.0 is running
     wait_for_service(vps_container["name"], "failapp-web.service")
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/failapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/failapp/current/.version"
     )
     assert success and stdout == "1.0.0"
 
@@ -902,7 +902,7 @@ WantedBy=multi-user.target
     wait_for_service(vps_container["name"], "failapp-web.service")
 
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/failapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/failapp/current/.version"
     )
     assert success and stdout == "1.0.0", (
         f"Expected v1.0.0 after auto-rollback, got: {stdout}"
@@ -929,7 +929,7 @@ Description=Rollback test app
 
 [Service]
 Type=simple
-ExecStart={install_dir}/rollbackapp
+ExecStart={app_dir}/current/rollbackapp
 WorkingDirectory={app_dir}
 Restart=no
 
@@ -985,7 +985,7 @@ WantedBy=multi-user.target
 
     # Version should still show 2.0.0 (failed deploy, no rollback)
     stdout, success = exec_in_container(
-        vps_container["name"], "cat /opt/fujin/rollbackapp/.install/.version"
+        vps_container["name"], "cat /opt/fujin/rollbackapp/current/.version"
     )
     assert success and stdout == "2.0.0", (
         f"Expected v2.0.0 (no rollback), got: {stdout}"

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -51,7 +51,7 @@ After={app_name}-web.socket
 
 [Service]
 Type=simple
-ExecStart={install_dir}/socketapp
+ExecStart={app_dir}/current/socketapp
 WorkingDirectory={app_dir}
 StandardInput=socket
 
@@ -131,7 +131,7 @@ Description=Cleanup task
 
 [Service]
 Type=oneshot
-ExecStart={install_dir}/timerapp
+ExecStart={app_dir}/current/timerapp
 WorkingDirectory={app_dir}
 """)
 
@@ -230,7 +230,7 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/staleapp
+ExecStart={app_dir}/current/staleapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -244,7 +244,7 @@ Description=Worker
 
 [Service]
 Type=simple
-ExecStart={install_dir}/staleapp
+ExecStart={app_dir}/current/staleapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -306,7 +306,7 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/dropinapp
+ExecStart={app_dir}/current/dropinapp
 WorkingDirectory={app_dir}
 Restart=always
 
@@ -431,7 +431,7 @@ Description=Web server
 
 [Service]
 Type=simple
-ExecStart={install_dir}/dropinclean
+ExecStart={app_dir}/current/dropinclean
 WorkingDirectory={app_dir}
 Restart=always
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -262,7 +262,7 @@ def test_config_app_dir(minimal_config):
 
 def test_config_app_bin_for_python_package(minimal_config):
     assert minimal_config.installation_mode == InstallationMode.PY_PACKAGE
-    assert minimal_config.app_bin == ".install/.venv/bin/testapp"
+    assert minimal_config.app_bin == "testapp"
 
 
 def test_config_app_bin_for_binary(minimal_config_dict):
@@ -270,4 +270,4 @@ def test_config_app_bin_for_binary(minimal_config_dict):
     del minimal_config_dict["python_version"]
 
     config = msgspec.convert(minimal_config_dict, type=Config)
-    assert config.app_bin == ".install/testapp"
+    assert config.app_bin == "testapp"

--- a/tests/test_down.py
+++ b/tests/test_down.py
@@ -1,7 +1,4 @@
-"""Tests for down command - user interaction and error handling.
-
-Uses shared minimal_config_dict fixture from conftest.py.
-"""
+"""Tests for down command."""
 
 from __future__ import annotations
 
@@ -12,10 +9,6 @@ import pytest
 
 from fujin.commands.down import Down
 from fujin.config import Config
-
-# ============================================================================
-# Confirmation Flow
-# ============================================================================
 
 
 def test_down_aborted_when_user_declines(minimal_config_dict):
@@ -31,17 +24,16 @@ def test_down_aborted_when_user_declines(minimal_config_dict):
     ):
         mock_connection.return_value.__enter__.return_value = mock_conn
         mock_connection.return_value.__exit__.return_value = None
-        mock_confirm.ask.return_value = False  # User declines
+        mock_confirm.ask.return_value = False
 
         down = Down()
         down()
 
-        # Connection should not be used if user declines
         assert not mock_conn.run.called
 
 
 def test_down_handles_keyboard_interrupt(minimal_config_dict):
-    """Down command handles Ctrl+C gracefully during confirmation."""
+    """Down command handles Ctrl+C gracefully."""
     config = msgspec.convert(minimal_config_dict, type=Config)
 
     with (
@@ -52,28 +44,20 @@ def test_down_handles_keyboard_interrupt(minimal_config_dict):
         mock_confirm.ask.side_effect = KeyboardInterrupt
 
         down = Down()
-
         with pytest.raises(SystemExit) as exc_info:
             down()
-
         assert exc_info.value.code == 0
 
 
-# ============================================================================
-# Successful Teardown
-# ============================================================================
-
-
-def test_down_successful_teardown_with_bundle(minimal_config_dict):
-    """Down successfully tears down when bundle exists."""
+def test_down_successful_teardown(minimal_config_dict):
+    """Down tears down the project successfully."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    # Mock responses for: version read, bundle exists check, uninstall
     mock_conn.run.side_effect = [
-        ("1.0.0", True),  # cat .version
-        ("", True),  # test -f bundle (exists)
-        ("", True),  # uninstall command
+        ("1.0.0", True),  # cat current/.version
+        ("", True),  # systemctl stop + rm + rm -rf
+        ("", True),  # userdel
     ]
 
     with (
@@ -90,10 +74,9 @@ def test_down_successful_teardown_with_bundle(minimal_config_dict):
         down = Down()
         down()
 
-        # Verify uninstall command was called
         calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        assert any("python3" in cmd and "uninstall" in cmd for cmd in calls)
         assert any("rm -rf" in cmd for cmd in calls)
+        assert any("userdel" in cmd for cmd in calls)
 
 
 def test_down_uses_config_version_when_version_file_missing(minimal_config_dict):
@@ -101,11 +84,10 @@ def test_down_uses_config_version_when_version_file_missing(minimal_config_dict)
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    # Version file read fails, bundle check, uninstall
     mock_conn.run.side_effect = [
-        ("", False),  # cat .version fails
-        ("", True),  # test -f bundle (exists)
-        ("", True),  # uninstall command
+        ("", False),  # cat current/.version fails
+        ("", True),  # cleanup commands
+        ("", True),  # userdel
     ]
 
     with (
@@ -122,95 +104,20 @@ def test_down_uses_config_version_when_version_file_missing(minimal_config_dict)
         down = Down()
         down()
 
-        # Should have tried to run uninstall with config version
         calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        assert any("testapp-1.0.0.pyz" in cmd for cmd in calls)
+        assert any("rm -rf" in cmd for cmd in calls)
 
 
-# ============================================================================
-# Force Flag Behavior
-# ============================================================================
-
-
-def test_down_fails_when_uninstall_fails_without_force(minimal_config_dict):
-    """Down raises error when uninstall fails and --force not set."""
+def test_down_full_flag_also_removes_caddy(minimal_config_dict):
+    """Down with --full flag includes Caddy removal."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    # Version read, bundle exists, uninstall fails
     mock_conn.run.side_effect = [
-        ("1.0.0", True),  # cat .version
-        ("", True),  # test -f bundle (exists)
-        ("", False),  # uninstall command fails
-    ]
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch("fujin.commands.down.Confirm") as mock_confirm,
-        patch.object(Down, "output", MagicMock()),
-    ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-        mock_confirm.ask.return_value = True
-
-        down = Down(force=False)
-
-        with pytest.raises(SystemExit) as exc_info:
-            down()
-
-        assert exc_info.value.code == 1
-
-
-def test_down_continues_with_force_when_uninstall_fails(minimal_config_dict):
-    """Down continues with force cleanup when uninstall fails and --force set."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-
-    # Version read, bundle exists, uninstall fails, force cleanup
-    mock_conn.run.side_effect = [
-        ("1.0.0", True),  # cat .version
-        ("", True),  # test -f bundle (exists)
-        ("", False),  # uninstall command fails
-        ("", True),  # rm -rf (force cleanup)
-    ]
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch("fujin.commands.down.Confirm") as mock_confirm,
-        patch("fujin.commands.down.log_operation"),
-        patch.object(Down, "output", MagicMock()),
-    ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-        mock_confirm.ask.return_value = True
-
-        down = Down(force=True)
-        down()
-
-        # Verify force cleanup was called
-        calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        # Should have two rm -rf calls: one in uninstall, one for force cleanup
-        assert sum("rm -rf" in cmd for cmd in calls) == 2
-
-
-# ============================================================================
-# Full Flag Behavior
-# ============================================================================
-
-
-def test_down_with_full_flag_uninstalls_caddy(minimal_config_dict):
-    """Down with --full flag also uninstalls Caddy."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-
-    # Version read, bundle exists, uninstall, caddy uninstall
-    mock_conn.run.side_effect = [
-        ("1.0.0", True),  # cat .version
-        ("", True),  # test -f bundle (exists)
-        ("", True),  # uninstall command
-        ("", True),  # caddy uninstall commands
+        ("1.0.0", True),  # cat current/.version
+        ("", True),  # cleanup commands
+        ("", True),  # userdel
+        ("", True),  # caddy uninstall (from caddy module)
     ]
 
     with (
@@ -232,9 +139,7 @@ def test_down_with_full_flag_uninstalls_caddy(minimal_config_dict):
         down = Down(full=True)
         down()
 
-        # Verify Caddy uninstall was attempted
-        mock_caddy.get_uninstall_commands.assert_called_once()
         calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        assert any(
-            "systemctl stop caddy" in cmd and "apt remove" in cmd for cmd in calls
-        )
+        cmd_str = " ".join(calls)
+        assert "rm -rf" in cmd_str
+        assert "userdel" in cmd_str

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -10,62 +10,34 @@ import pytest
 from fujin.commands.prune import Prune
 from fujin.config import Config
 
-# base_config fixture from conftest.py
-
-
-# ============================================================================
-# Validation
-# ============================================================================
-
-
-def test_prune_with_keep_less_than_1_raises_error(minimal_config_dict):
-    """prune with --keep < 1 raises error."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch.object(Prune, "output", MagicMock()),
-    ):
-        prune = Prune(keep=0)
-
-        with pytest.raises(SystemExit) as exc_info:
-            prune()
-
-        assert exc_info.value.code == 1
-
-
-# ============================================================================
-# No Versions Scenarios
-# ============================================================================
-
 
 @pytest.mark.parametrize(
     "run_side_effects,keep,expected_message",
     [
-        # No versions directory
+        # No releases directory
         (
             [("", False)],
             2,
-            "No versions directory found. Nothing to prune.",
+            "No releases directory found. Nothing to prune.",
         ),
-        # Empty versions directory
+        # Empty releases directory
         (
             [("", True), ("", True)],
             2,
-            "No versions found to prune",
+            "No releases found to prune",
         ),
-        # Fewer versions than keep
+        # Fewer releases than keep
         (
-            [("", True), ("testapp-1.0.0.pyz\ntestapp-0.9.0.pyz", True)],
+            [("", True), ("1.0.0\n0.9.0", True)],
             3,
-            "Only 2 versions found. Nothing to prune (keep=3).",
+            "Only 2 release(s) found. Nothing to prune (keep=3).",
         ),
     ],
 )
-def test_prune_no_versions_scenarios(
+def test_prune_no_releases_scenarios(
     minimal_config_dict, run_side_effects, keep, expected_message
 ):
-    """prune handles various no-versions scenarios correctly."""
+    """prune handles various no-releases scenarios correctly."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
     mock_conn.run.side_effect = run_side_effects
@@ -81,29 +53,20 @@ def test_prune_no_versions_scenarios(
         prune = Prune(keep=keep)
         prune()
 
-        # Should show info message
         mock_output.info.assert_called_with(expected_message)
 
 
-# ============================================================================
-# Successful Pruning
-# ============================================================================
-
-
-def test_prune_deletes_old_versions_when_user_confirms(minimal_config_dict):
-    """prune deletes old versions when user confirms."""
+def test_prune_deletes_old_releases_when_user_confirms(minimal_config_dict):
+    """prune deletes old releases when user confirms."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    # 4 versions, newest first (ls -1t sorts by time)
-    versions_output = (
-        "testapp-1.3.0.pyz\ntestapp-1.2.0.pyz\ntestapp-1.1.0.pyz\ntestapp-1.0.0.pyz"
-    )
-
+    # 4 releases, newest first
     mock_conn.run.side_effect = [
-        ("", True),  # test -d
-        (versions_output, True),  # ls -1t
-        ("", True),  # rm command
+        ("", True),  # test -d releases/
+        ("1.3.0\n1.2.0\n1.1.0\n1.0.0", True),  # ls -1t
+        ("", True),  # rm -rf 1.1.0
+        ("", True),  # rm -rf 1.0.0
     ]
 
     with (
@@ -119,17 +82,13 @@ def test_prune_deletes_old_versions_when_user_confirms(minimal_config_dict):
         prune = Prune(keep=2)
         prune()
 
-        # Verify deletion command was called
         calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        rm_cmd = [cmd for cmd in calls if "rm -f" in cmd][0]
+        # Should delete 1.1.0 and 1.0.0, keep 1.3.0 and 1.2.0
+        assert any("rm -rf" in c and "1.1.0" in c for c in calls)
+        assert any("rm -rf" in c and "1.0.0" in c for c in calls)
+        assert not any("1.3.0" in c for c in calls if "rm -rf" in c)
+        assert not any("1.2.0" in c for c in calls if "rm -rf" in c)
 
-        # Should keep newest 2 (1.3.0, 1.2.0), delete oldest 2 (1.1.0, 1.0.0)
-        assert "testapp-1.1.0.pyz" in rm_cmd
-        assert "testapp-1.0.0.pyz" in rm_cmd
-        assert "testapp-1.3.0.pyz" not in rm_cmd
-        assert "testapp-1.2.0.pyz" not in rm_cmd
-
-        # Should show success message
         mock_output.success.assert_called()
 
 
@@ -138,51 +97,39 @@ def test_prune_aborts_when_user_declines(minimal_config_dict):
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    versions_output = (
-        "testapp-1.3.0.pyz\ntestapp-1.2.0.pyz\ntestapp-1.1.0.pyz\ntestapp-1.0.0.pyz"
-    )
-
     mock_conn.run.side_effect = [
         ("", True),  # test -d
-        (versions_output, True),  # ls -1t
+        ("1.3.0\n1.2.0\n1.1.0\n1.0.0", True),  # ls -1t
     ]
 
     with (
         patch("fujin.config.Config.read", return_value=config),
         patch("fujin.connection.connection") as mock_connection,
         patch("fujin.commands.prune.Confirm") as mock_confirm,
-        patch.object(Prune, "output", MagicMock()) as mock_output,
+        patch.object(Prune, "output", MagicMock()),
     ):
         mock_connection.return_value.__enter__.return_value = mock_conn
         mock_connection.return_value.__exit__.return_value = None
-        mock_confirm.ask.return_value = False  # User declines
+        mock_confirm.ask.return_value = False
 
         prune = Prune(keep=2)
         prune()
 
-        # Should not call rm command (only 2 run calls: test -d and ls)
-        assert mock_conn.run.call_count == 2
-
-        # Should not show success message
-        assert not mock_output.success.called
-
-
-# ============================================================================
-# Keep Parameter Behavior
-# ============================================================================
+        # Should NOT call rm
+        calls = [call[0][0] for call in mock_conn.run.call_args_list]
+        assert not any("rm -rf" in c for c in calls)
 
 
 def test_prune_with_keep_1_deletes_all_but_newest(minimal_config_dict):
-    """prune with --keep 1 deletes all but the newest version."""
+    """prune with --keep 1 deletes all but the newest release."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    versions_output = "testapp-2.0.0.pyz\ntestapp-1.0.0.pyz\ntestapp-0.9.0.pyz"
-
     mock_conn.run.side_effect = [
         ("", True),  # test -d
-        (versions_output, True),  # ls -1t
-        ("", True),  # rm command
+        ("2.0.0\n1.0.0\n0.9.0", True),  # ls -1t
+        ("", True),  # rm -rf 1.0.0
+        ("", True),  # rm -rf 0.9.0
     ]
 
     with (
@@ -198,26 +145,20 @@ def test_prune_with_keep_1_deletes_all_but_newest(minimal_config_dict):
         prune = Prune(keep=1)
         prune()
 
-        # Verify deletion command
         calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        rm_cmd = [cmd for cmd in calls if "rm -f" in cmd][0]
-
-        # Should keep only newest (2.0.0), delete others
-        assert "testapp-1.0.0.pyz" in rm_cmd
-        assert "testapp-0.9.0.pyz" in rm_cmd
-        assert "testapp-2.0.0.pyz" not in rm_cmd
+        assert any("rm -rf" in c and "1.0.0" in c for c in calls)
+        assert any("rm -rf" in c and "0.9.0" in c for c in calls)
+        assert not any("2.0.0" in c for c in calls if "rm -rf" in c)
 
 
-def test_prune_with_keep_5_keeps_all_if_only_3_versions(minimal_config_dict):
-    """prune with --keep 5 keeps all versions if only 3 exist."""
+def test_prune_with_no_filtering_needed(minimal_config_dict):
+    """prune with keep >= count does nothing."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    versions_output = "testapp-1.2.0.pyz\ntestapp-1.1.0.pyz\ntestapp-1.0.0.pyz"
-
     mock_conn.run.side_effect = [
         ("", True),  # test -d
-        (versions_output, True),  # ls -1t
+        ("1.0.0\n0.9.0", True),  # ls -1t
     ]
 
     with (
@@ -231,59 +172,20 @@ def test_prune_with_keep_5_keeps_all_if_only_3_versions(minimal_config_dict):
         prune = Prune(keep=5)
         prune()
 
-        # Should show info message about nothing to prune
         mock_output.info.assert_called_with(
-            "Only 3 versions found. Nothing to prune (keep=5)."
+            "Only 2 release(s) found. Nothing to prune (keep=5)."
         )
 
 
-# ============================================================================
-# File Filtering
-# ============================================================================
-
-
-def test_prune_ignores_non_bundle_files(minimal_config_dict):
-    """prune ignores files that don't match the bundle pattern."""
+def test_prune_keep_zero_raises_error(minimal_config_dict):
+    """prune with --keep 0 raises error."""
     config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-
-    # Mix of valid bundles and other files
-    versions_output = (
-        "testapp-1.2.0.pyz\n"
-        "testapp-1.1.0.pyz\n"
-        "testapp-1.0.0.pyz\n"
-        "README.md\n"
-        "backup.tar.gz\n"
-        "other-app-1.0.0.pyz"  # Different app name
-    )
-
-    mock_conn.run.side_effect = [
-        ("", True),  # test -d
-        (versions_output, True),  # ls -1t
-        ("", True),  # rm command
-    ]
 
     with (
         patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch("fujin.commands.prune.Confirm") as mock_confirm,
         patch.object(Prune, "output", MagicMock()),
     ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-        mock_confirm.ask.return_value = True
-
-        prune = Prune(keep=2)
-        prune()
-
-        # Verify only valid bundles are deleted
-        calls = [call[0][0] for call in mock_conn.run.call_args_list]
-        rm_cmd = [cmd for cmd in calls if "rm -f" in cmd][0]
-
-        # Should delete oldest valid bundle
-        assert "testapp-1.0.0.pyz" in rm_cmd
-
-        # Should NOT delete non-bundle files or other app bundles
-        assert "README.md" not in rm_cmd
-        assert "backup.tar.gz" not in rm_cmd
-        assert "other-app-1.0.0.pyz" not in rm_cmd
+        with pytest.raises(SystemExit) as exc:
+            prune = Prune(keep=0)
+            prune()
+        assert exc.value.code == 1

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,8 +1,4 @@
-"""Tests for rollback command - error handling and user interaction.
-
-Full rollback workflows are tested in integration tests.
-See tests/integration/test_full_deploy.py
-"""
+"""Tests for rollback command."""
 
 from __future__ import annotations
 
@@ -14,123 +10,17 @@ import pytest
 from fujin.commands.rollback import Rollback
 from fujin.config import Config
 
-# ============================================================================
-# User Interaction
-# ============================================================================
 
-
-def test_rollback_aborts_on_keyboard_interrupt(minimal_config_dict):
-    """Rollback handles Ctrl+C gracefully during version selection."""
+def test_rollback_no_previous_versions(minimal_config_dict):
+    """Rollback shows info when no previous versions exist."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    # Combined: cat .version; echo '---'; ls -1t .versions
+    # Only current version in releases/
     mock_conn.run.return_value = (
-        "1.0.0\n---\ntestapp-1.0.0.pyz\ntestapp-0.9.0.pyz",
+        "1.0.0\n---\n1.0.0",
         True,
     )
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch("fujin.commands.rollback.IntPrompt") as mock_prompt,
-        patch("fujin.commands.rollback.Console"),
-        patch.object(Rollback, "output", MagicMock()),
-    ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-        mock_prompt.ask.side_effect = KeyboardInterrupt
-
-        rollback = Rollback()
-
-        with pytest.raises(SystemExit) as exc_info:
-            rollback()
-
-        assert exc_info.value.code == 0
-
-
-def test_rollback_aborts_when_user_declines_confirmation(minimal_config_dict):
-    """Rollback aborts when user declines confirmation."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-
-    # Combined: cat .version; echo '---'; ls -1t .versions
-    mock_conn.run.return_value = (
-        "1.1.0\n---\ntestapp-1.1.0.pyz\ntestapp-1.0.0.pyz",
-        True,
-    )
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch("fujin.commands.rollback.IntPrompt") as mock_prompt,
-        patch("fujin.commands.rollback.Console"),
-        patch("fujin.commands.rollback.Confirm") as mock_confirm,
-        patch.object(Rollback, "output", MagicMock()),
-    ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-        mock_prompt.ask.return_value = 1  # Select first option
-        mock_confirm.ask.return_value = False  # User declines
-
-        rollback = Rollback()
-        rollback()
-
-        # Should only have called the combined command, not uninstall/install
-        assert mock_conn.run.call_count == 1
-
-
-def test_rollback_strict_fails_when_no_targets_available(minimal_config_dict):
-    """Rollback with --strict exits with error when no rollback targets are available."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-    mock_conn.run.return_value = ("", False)  # Command failed entirely
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch.object(Rollback, "output", MagicMock()),
-    ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-
-        rollback = Rollback(strict=True)
-
-        with pytest.raises(SystemExit) as exc_info:
-            rollback()
-
-        assert exc_info.value.code == 1
-
-
-def test_rollback_strict_fails_when_only_current_version_exists(minimal_config_dict):
-    """Rollback with --strict exits with error when only the current version exists."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-
-    # Combined: cat .version; echo '---'; ls -1t .versions (only current version)
-    mock_conn.run.return_value = ("1.0.0\n---\ntestapp-1.0.0.pyz", True)
-
-    with (
-        patch("fujin.config.Config.read", return_value=config),
-        patch("fujin.connection.connection") as mock_connection,
-        patch.object(Rollback, "output", MagicMock()),
-    ):
-        mock_connection.return_value.__enter__.return_value = mock_conn
-        mock_connection.return_value.__exit__.return_value = None
-
-        rollback = Rollback(strict=True)
-
-        with pytest.raises(SystemExit) as exc_info:
-            rollback()
-
-        assert exc_info.value.code == 1
-
-
-def test_rollback_shows_info_when_no_targets_available(minimal_config_dict):
-    """Rollback shows info when no rollback targets are available."""
-    config = msgspec.convert(minimal_config_dict, type=Config)
-    mock_conn = MagicMock()
-    mock_conn.run.return_value = ("", False)  # Command failed entirely
 
     with (
         patch("fujin.config.Config.read", return_value=config),
@@ -143,35 +33,33 @@ def test_rollback_shows_info_when_no_targets_available(minimal_config_dict):
         rollback = Rollback()
         rollback()
 
-        # Should show info message
         mock_output.info.assert_called_with(
             "No previous versions available for rollback"
         )
 
 
-def test_rollback_shows_info_when_only_current_version_exists(minimal_config_dict):
-    """Rollback shows info when only the current version exists (no previous versions)."""
+def test_rollback_strict_mode_no_versions(minimal_config_dict):
+    """Rollback in strict mode exits with error when no previous versions."""
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
-    # Combined: cat .version; echo '---'; ls -1t .versions (only current version)
-    mock_conn.run.return_value = ("1.0.0\n---\ntestapp-1.0.0.pyz", True)
+    mock_conn.run.return_value = (
+        "1.0.0\n---\n1.0.0",
+        True,
+    )
 
     with (
         patch("fujin.config.Config.read", return_value=config),
         patch("fujin.connection.connection") as mock_connection,
-        patch.object(Rollback, "output", MagicMock()) as mock_output,
+        patch.object(Rollback, "output", MagicMock()),
     ):
         mock_connection.return_value.__enter__.return_value = mock_conn
         mock_connection.return_value.__exit__.return_value = None
 
-        rollback = Rollback()
-        rollback()
-
-        # Should show info message about no previous versions
-        mock_output.info.assert_called_with(
-            "No previous versions available for rollback"
-        )
+        rollback = Rollback(strict=True)
+        with pytest.raises(SystemExit) as exc:
+            rollback()
+        assert exc.value.code == 1
 
 
 def test_rollback_previous_flag_auto_selects_most_recent(minimal_config_dict):
@@ -179,12 +67,18 @@ def test_rollback_previous_flag_auto_selects_most_recent(minimal_config_dict):
     config = msgspec.convert(minimal_config_dict, type=Config)
     mock_conn = MagicMock()
 
+    # Current: 1.1.0, available releases: 1.1.0, 1.0.0, 0.9.0
     mock_conn.run.side_effect = [
-        # Combined: cat .version; echo '---'; ls -1t .versions
-        ("1.1.0\n---\ntestapp-1.1.0.pyz\ntestapp-1.0.0.pyz\ntestapp-0.9.0.pyz", True),
-        (None, True),  # test -f (bundle exists)
-        ("", True),  # uninstall
-        ("", True),  # install + cleanup
+        # Combined: readlink + ls -1t releases/
+        ("1.1.0\n---\n1.1.0\n1.0.0\n0.9.0", True),
+        # test -d releases/1.0.0
+        ("", True),
+        # ln -sfn + mv (atomic swap)
+        ("", True),
+        # systemctl restart
+        ("", True),
+        # Cleanup newer releases
+        ("", True),
     ]
 
     with (
@@ -201,14 +95,91 @@ def test_rollback_previous_flag_auto_selects_most_recent(minimal_config_dict):
         rollback = Rollback(previous=True)
         rollback()
 
-        # Should NOT have prompted for version selection
         mock_prompt.ask.assert_not_called()
         mock_confirm.ask.assert_not_called()
-
-        # Should have shown info about rolling back to the most recent previous (1.0.0)
         mock_output.info.assert_any_call("Rolling back from 1.1.0 to 1.0.0...")
-
-        # Should show success message
         mock_output.success.assert_called_with(
             "Rollback to version 1.0.0 completed successfully!"
         )
+
+
+def test_rollback_error_when_release_missing(minimal_config_dict):
+    """Rollback errors when selected release directory is missing."""
+    config = msgspec.convert(minimal_config_dict, type=Config)
+    mock_conn = MagicMock()
+
+    mock_conn.run.side_effect = [
+        ("1.1.0\n---\n1.1.0\n1.0.0", True),  # readlink + ls
+        ("", False),  # test -d (release missing!)
+    ]
+
+    with (
+        patch("fujin.config.Config.read", return_value=config),
+        patch("fujin.connection.connection") as mock_connection,
+        patch.object(Rollback, "output", MagicMock()) as mock_output,
+    ):
+        mock_connection.return_value.__enter__.return_value = mock_conn
+        mock_connection.return_value.__exit__.return_value = None
+
+        rollback = Rollback(previous=True)
+        rollback()
+
+        mock_output.error.assert_called()
+        args = mock_output.error.call_args[0][0]
+        assert "not found" in args
+
+
+def test_rollback_aborts_on_keyboard_interrupt(minimal_config_dict):
+    """Rollback handles Ctrl+C gracefully during version selection."""
+    config = msgspec.convert(minimal_config_dict, type=Config)
+    mock_conn = MagicMock()
+
+    mock_conn.run.return_value = (
+        "1.0.0\n---\n1.0.0\n0.9.0",
+        True,
+    )
+
+    with (
+        patch("fujin.config.Config.read", return_value=config),
+        patch("fujin.connection.connection") as mock_connection,
+        patch("fujin.commands.rollback.IntPrompt") as mock_prompt,
+        patch("fujin.commands.rollback.Console"),
+        patch.object(Rollback, "output", MagicMock()),
+    ):
+        mock_connection.return_value.__enter__.return_value = mock_conn
+        mock_connection.return_value.__exit__.return_value = None
+        mock_prompt.ask.side_effect = KeyboardInterrupt
+
+        rollback = Rollback()
+        with pytest.raises(SystemExit) as exc_info:
+            rollback()
+        assert exc_info.value.code == 0
+
+
+def test_rollback_aborts_when_user_declines_confirmation(minimal_config_dict):
+    """Rollback aborts when user declines confirmation."""
+    config = msgspec.convert(minimal_config_dict, type=Config)
+    mock_conn = MagicMock()
+
+    mock_conn.run.return_value = (
+        "1.1.0\n---\n1.1.0\n1.0.0",
+        True,
+    )
+
+    with (
+        patch("fujin.config.Config.read", return_value=config),
+        patch("fujin.connection.connection") as mock_connection,
+        patch("fujin.commands.rollback.IntPrompt") as mock_prompt,
+        patch("fujin.commands.rollback.Confirm") as mock_confirm,
+        patch("fujin.commands.rollback.Console"),
+        patch.object(Rollback, "output", MagicMock()),
+    ):
+        mock_connection.return_value.__enter__.return_value = mock_conn
+        mock_connection.return_value.__exit__.return_value = None
+        mock_prompt.ask.return_value = 1  # Select first option
+        mock_confirm.ask.return_value = False  # But decline confirmation
+
+        rollback = Rollback()
+        rollback()
+
+        mock_confirm.ask.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "fujin-cli"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "cappa" },
@@ -402,7 +402,7 @@ docs = [
 
 [[package]]
 name = "fujin-secrets-1password"
-version = "0.26.1"
+version = "0.27.1"
 source = { editable = "plugins/fujin-secrets-1password" }
 dependencies = [
     { name = "fujin-cli" },
@@ -417,7 +417,7 @@ requires-dist = [
 
 [[package]]
 name = "fujin-secrets-bitwarden"
-version = "0.26.1"
+version = "0.27.1"
 source = { editable = "plugins/fujin-secrets-bitwarden" }
 dependencies = [
     { name = "fujin-cli" },
@@ -432,7 +432,7 @@ requires-dist = [
 
 [[package]]
 name = "fujin-secrets-doppler"
-version = "0.26.1"
+version = "0.27.1"
 source = { editable = "plugins/fujin-secrets-doppler" }
 dependencies = [
     { name = "fujin-cli" },
@@ -447,7 +447,7 @@ requires-dist = [
 
 [[package]]
 name = "fujin-secrets-env"
-version = "0.26.1"
+version = "0.27.1"
 source = { editable = "plugins/fujin-secrets-env" }
 dependencies = [
     { name = "fujin-cli" },


### PR DESCRIPTION
.version in the release folder is useless
.appenv should not really change per versions
the original systemd config and caddy file should probably be kept in the  release folder, to be able to replace and swap them if needed

We need to effecility determine which systemd file has changed (has) and swap them when rolling back before the restart, same for deploy too. We can even skip the verify on the files that did not changed


Closes #71 